### PR TITLE
Feature/phase 2 nav expansion

### DIFF
--- a/content/about.ts
+++ b/content/about.ts
@@ -1,0 +1,31 @@
+// content/about.ts
+// All about-page and homepage bio content.
+// Replace every TODO comment before merging to main.
+
+export const about = {
+  name:            'Hammayo Babar',     // Full name — desktop
+  shortName:       'Hammy Babar',       // Short name — mobile (below md breakpoint)
+  tagline:         'Senior Backend Engineer',
+  careerStartYear: 2004,                // Years of experience = currentYear - careerStartYear
+
+  // Homepage bio — first paragraph uses {stardate} and {years} tokens.
+  // {stardate} = YYYYMM.DD computed client-side daily.
+  // {years}    = currentYear - careerStartYear, updates each Jan 1.
+  homepageBioTemplate: "Captain's log, stardate {stardate}: For last {years} years, I've boldly navigated the digital frontier, charting solutions across uncharted sectors—finance's nebulae, justice's asteroid belts, and the bureaucratic wormholes of public service.",
+
+  // Additional static paragraphs shown below the template paragraph on the homepage.
+  homepageBioExtra: [
+    "Armed with a tricorder of Microsoft tech and a starship engineered from micro-services and Docker containers at warp speed, I've allied with Starfleet's HMPPS to dismantle legacy system Borgs and assimilate innovation. My crew? A cross-functional away team, trained in the Vulcan discipline of clean code and the Klingon art of relentless problem-solving.",
+    'Mission priority: To seek out new patterns, elevate civilizations with scalable tech, and ensure no enterprise is left stranded in the alpha quadrant of obsolescence. Engage at will — let\'s pioneer the final frontier of software, where no challenge has gone before. 🖖',
+  ],
+
+  // /about page — longer professional bio. Replace TODO before merging.
+  bio: 'TODO: Replace with your professional bio. A few sentences about your background, the domains you have worked in, and what drives you.',
+
+  sectors:   ['Distributed Systems', 'Platform Engineering', 'FinTech', 'Justice & Public Service', 'Microservices'],
+  philosophy: 'Build for the next engineer, not just the next deadline.',
+
+  // next/image src — prepend basePath in the component.
+  // Falls back to /_hb-logo.png if avatar.jpg is absent.
+  avatarPath: '/images/avatar.jpg',
+};

--- a/content/blogs.ts
+++ b/content/blogs.ts
@@ -1,0 +1,10 @@
+// content/blogs.ts
+// Phase 2: placeholder config only.
+// Phase 3 adds posts-per-page, tag config, and the MDX pipeline.
+
+export const blogs = {
+  placeholderTitle:       'Blogs',
+  placeholderDescription: 'Technical writing on backend systems, architecture, and engineering craft.',
+  comingSoonMessage:      'Posts coming soon — check back later.',
+  backLinkText:           '← Back to home',
+};

--- a/content/cv.ts
+++ b/content/cv.ts
@@ -1,0 +1,34 @@
+// content/cv.ts
+// Single source of truth for CV data.
+// Phase 2: skills filled in, roles/education scaffolded with placeholders.
+// Phase 3+: expand roles and education with real entries.
+import { SOCIAL } from '@/lib/constants';
+
+export const cv = {
+  linkedIn: SOCIAL.linkedin,
+  placeholderText: 'Full CV coming soon — view my LinkedIn profile in the meantime.',
+
+  skills: {
+    languages: ['Go', 'C#', '.NET', 'TypeScript', 'SQL', 'Python'],
+    platforms: ['Azure', 'Kubernetes', 'Docker', 'GitHub Actions', 'AWS'],
+    tools:     ['Kafka', 'Redis', 'PostgreSQL', 'Terraform', 'Grafana'],
+  },
+
+  roles: [
+    {
+      title:   'Senior Backend Engineer', // TODO: replace with real role
+      company: 'HMPPS / MoJ',            // TODO: replace with real company
+      period:  '2020 – present',          // TODO: replace with real period
+      summary: 'Platform infrastructure and microservices.',
+      tags:    ['Go', 'Kubernetes', 'Azure'],
+    },
+  ],
+
+  education: [
+    {
+      institution:   'TODO: University name',  // TODO: replace
+      qualification: 'TODO: Degree',           // TODO: replace
+      year:          2004,                     // TODO: replace
+    },
+  ],
+};

--- a/docs/superpowers/plans/2026-04-10-plan-1-completion.md
+++ b/docs/superpowers/plans/2026-04-10-plan-1-completion.md
@@ -1,10 +1,12 @@
-# Plan 1 Completion Summary — Foundation
+# Phase 1: Foundation — Consolidated Summary
 
-**Branch:** `feature/plan-1-foundation`  
+**Branch:** `feature/plan-1-foundation` → merged to `develop` → merged to `main` via PR #12  
 **Date completed:** 2026-04-10  
-**Status:** Complete — branch pushed, worktree preserved, PR pending  
-**Based on:** `docs/superpowers/plans/2026-04-10-plan-1-foundation.md`  
+**Status:** ✅ Complete and merged  
+**Detailed plan steps:** `docs/superpowers/plans/2026-04-10-plan-1-foundation.md`  
 **Design spec:** `docs/superpowers/specs/2026-04-10-website-revamp-design.md`
+
+> This is the single reference document for all Phase 1 changes. The foundation plan file (`plan-1-foundation.md`) contains the step-by-step task breakdown; this doc summarises what was actually delivered, deviations, and the commit log.
 
 ---
 
@@ -112,10 +114,20 @@ c525fac style: richer animated gradient on hero HAMMAYO title
 
 ---
 
-## Next Steps
+## Phase Progression
 
-- **Plan 2 — Blog & MDX pipeline** (`docs/superpowers/plans/` — to be written)
-  - MDX content pipeline, `/blog`, `/blog/[slug]`, OG images, RSS feed, sitemap extension, tag filtering
-- **Plan 3 — Pages & Navigation** (`docs/superpowers/plans/` — to be written)
-  - Homepage expansion, `/about`, `/cv`, `/uses`, mobile sheet nav, `/blogs` redirect, contact/projects redesign
-- Merge `feature/plan-1-foundation` → `develop` when Plans 2 & 3 are ready, or create PR now for review
+| Phase | Description | Status |
+|---|---|---|
+| **Phase 1** | Foundation — this document | ✅ Merged to `main` (PR #12) |
+| **Phase 2** | Pages & Navigation | ✅ Complete — `feature/phase-2-nav-expansion` |
+| **Phase 3** | Blog & MDX pipeline | ⏳ Pending |
+
+Phase 2 summary: `docs/superpowers/plans/2026-04-11-phase-2-nav-expansion.md`
+
+### Phase 1 constraints superseded by Phase 2
+
+| Original Phase 1 value | Replaced in Phase 2 | Why |
+|---|---|---|
+| Header `bg-white/80 dark:bg-zinc-950/80` | `bg-background/95 backdrop-blur-md` | Better contrast; `/80` let animated bg bleed through |
+| Progress bar at `top-[45px]` (fixed) | `absolute bottom-0` inside `<Header>` | Hardcoded value misaligned on mobile |
+| `ctaButton` using `gradient-bg` scheme vars | Hardcoded `from-violet-600 via-purple-600 to-indigo-600` | Scheme vars produced washed-out colours in morning/silver scheme |

--- a/docs/superpowers/plans/2026-04-10-plan-1-foundation.md
+++ b/docs/superpowers/plans/2026-04-10-plan-1-foundation.md
@@ -1,6 +1,8 @@
 # Plan 1: Foundation — Dependency Upgrades + Architecture + Design System
 
-> **Status: COMPLETE** — branch `feature/plan-1-foundation`, completed 2026-04-10. See `2026-04-10-plan-1-completion.md` for full summary including deviations and QA fixes.
+> **Status: ✅ COMPLETE** — branch `feature/plan-1-foundation`, merged to `main` via PR #12 on 2026-04-10.  
+> **Consolidated summary (deviations, QA fixes, phase progression):** `docs/superpowers/plans/2026-04-10-plan-1-completion.md`  
+> This file contains the original step-by-step task breakdown for reference only.
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 

--- a/docs/superpowers/plans/2026-04-11-phase-2-nav-expansion.md
+++ b/docs/superpowers/plans/2026-04-11-phase-2-nav-expansion.md
@@ -10,6 +10,57 @@
 
 ---
 
+## ✅ Phase 2 Complete — Implementation Summary
+
+**Branch:** `feature/phase-2-nav-expansion`  
+**Completed:** 2026-04-12
+
+All 10 plan tasks delivered. Post-implementation polish applied in the same branch. See deviations from spec noted below.
+
+### Delivered (plan tasks)
+
+| Task | Description | Status |
+|---|---|---|
+| 1 | Foundation — `PAGE_META`, `SITE_LAUNCH_YEAR`, `ctaButton` CVA, delete tailwind shim | ✅ |
+| 2 | Content data files — `content/about.ts`, `content/blogs.ts`, `content/cv.ts` | ✅ |
+| 3 | Mobile sheet nav, active link gradient, dynamic copyright year (`CopyrightYear`) | ✅ |
+| 4 | Homepage expansion — `HomepageBio`, skills strip, CTA row | ✅ |
+| 5 | `/about` page — avatar, bio, sectors, philosophy | ✅ |
+| 6 | `/blogs` placeholder — data-driven, styled | ✅ |
+| 7 | `/cv` placeholder — LinkedIn link, data-driven | ✅ |
+| 8 | `/projects` redesign — scheme-aware topic tags, gradient heading, metadata | ✅ |
+| 9 | `/contact` redesign — `ContactCard` components, gradient heading, metadata | ✅ |
+| 10 | Sitemap updated with all Phase 2 routes using `SITE_URL` | ✅ |
+
+### Post-implementation polish (same branch)
+
+| Fix | File(s) affected |
+|---|---|
+| Page layouts — About/Blogs/CV aligned with Contact/Projects (`mb-6` header block) | `src/app/about/page.tsx`, `src/app/blogs/page.tsx`, `src/app/cv/page.tsx` |
+| Nav dark mode — header `bg-background/95 backdrop-blur-md` (was `/80 backdrop-blur-xl`, bled through) | `src/features/shared/header.tsx` |
+| Active nav link — trailing-slash-safe compare (`pathname.replace(/\/$/, '')`) + inline gradient span | `src/features/shared/header.tsx` |
+| Gradient text contrast in light mode — `brightness(0.65) saturate(1.3)` filter | `src/app/globals.css` |
+| Font — switched body font to JetBrains Mono (single font, terminal aesthetic) | `src/app/layout.tsx` |
+| CTA buttons — hardcoded `violet-600 → purple-600 → indigo-600` gradient; scheme vars (`gradient-bg`) were too light | `src/design/variants.ts` |
+| Contact card buttons — use `ctaButton` variant for visual consistency with home page CTA | `src/features/contact/contact-card.tsx` |
+| Theme toggle — dropdown opens `side="top"` (no footer overlap); menu border `zinc-200/zinc-700` (visible in light mode) | `src/features/shared/theme-toggle.tsx`, `src/features/shared/ui/dropdown-menu.tsx` |
+| Footer — inner container aligned to header using `px-4 mx-auto max-w-7xl` | `src/features/shared/footer.tsx` |
+| Mobile sheet — solid background `bg-white dark:bg-zinc-800`; `bg-background` bled through fixed animated background | `src/features/shared/ui/sheet.tsx` |
+| Accessibility — `<SheetTitle className="sr-only">` added to satisfy Radix Dialog requirement | `src/features/shared/header.tsx` |
+| Route progress bar — moved inside `<Header>` as `absolute bottom-0`; double-rAF fix so animation actually runs | `src/features/shared/route-progress.tsx`, `src/features/shared/header.tsx` |
+| Page transitions — removed `y` translate (caused reflow/jank); opacity-only fade 150ms | `src/features/shared/page-transition-wrapper.tsx` |
+
+### Deviations from spec
+
+| Spec said | What was built | Reason |
+|---|---|---|
+| `ctaButton` uses `gradient-bg` (scheme CSS vars) | Hardcoded `from-violet-600 via-purple-600 to-indigo-600` | Scheme vars produced washed-out colours in morning/silver scheme |
+| Progress bar at `top-[45px]` (fixed) | `absolute bottom-0` inside `<Header>` | Hardcoded value misaligned on mobile; inside-header approach is layout-agnostic |
+| `<NavLinks>` as isolated client component | Header updated directly (already `'use client'`) | Header was already a client component; isolation provided no benefit |
+| Sheet uses `bg-background` | `bg-white dark:bg-zinc-800` | `bg-background` not reliably opaque over fixed animated background |
+
+---
+
 ## Codebase Facts (read before starting)
 
 - CSS scheme vars: `--scheme-from`, `--scheme-via`, `--scheme-to`, `--scheme-glow`, `--scheme-accent`, `--scheme-border`

--- a/docs/superpowers/plans/2026-04-11-phase-2-nav-expansion.md
+++ b/docs/superpowers/plans/2026-04-11-phase-2-nav-expansion.md
@@ -1,0 +1,1362 @@
+# Phase 2: Nav Expansion & Pages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver all navigable pages and full navigation structure — mobile nav, homepage expansion, /about, /blogs placeholder, /cv placeholder, /projects and /contact redesign, dynamic footer year.
+
+**Architecture:** Sequential tasks; earlier tasks unblock later ones. Content data files created before any UI that reads them. All new components use `useScheme()` + CSS vars (`--scheme-from/via/to`, `--scheme-glow`, `--scheme-accent`). `gradientText`, `glowCard`, `accentTag` CVA variants from `src/design/variants.ts` used throughout — no ad-hoc colour classes. Every new page shell wraps content in `PageTransitionWrapper` with `flex-1 flex flex-col` — never `min-h-screen` or custom overflow. Header is already `'use client'` with `usePathname` — update directly.
+
+**Tech Stack:** Next.js 16, Tailwind v4, Framer Motion, Radix Sheet (already in `src/features/shared/ui/sheet.tsx`), `class-variance-authority`, `next/image` with `imageLoader`
+
+---
+
+## Codebase Facts (read before starting)
+
+- CSS scheme vars: `--scheme-from`, `--scheme-via`, `--scheme-to`, `--scheme-glow`, `--scheme-accent`, `--scheme-border`
+- `gradient-text` utility: sets background gradient from the three scheme vars, clips to text
+- `gradient-bg` utility: same gradient as background fill
+- `scheme-glow` utility: `box-shadow: 0 0 20px var(--scheme-glow)`
+- `scheme-border` utility: `border-color: var(--scheme-border)`
+- `animate-gradient` class: `background-size: 300%; animation: animatedgradient 6s ease infinite alternate`
+- `useScheme()` from `@/providers/scheme-provider` returns `{ schemeName, scheme }` where `scheme` has `.from`, `.via`, `.to`, `.glow`, `.accent`, `.border`
+- `CardEffects` from `@/features/shared/ui/card-effects` — existing glow card wrapper with Framer Motion
+- `accentTag`, `glowCard`, `gradientText` CVA already in `src/design/variants.ts`
+- `SOCIAL.linkedin` = `'https://linkedin.com/in/hammayo'` in `src/lib/constants.ts`
+- `basePath` from `@/lib/env` — prepend to image paths (e.g. `${basePath}/images/avatar.jpg`)
+- `imageLoader` from `@/lib/imageLoader` — required for `next/image` on GitHub Pages static export
+- Root layout: `h-dvh flex flex-col overflow-hidden` > `main` with `flex-1 flex flex-col overflow-y-auto pt-16 pb-4 relative z-[1]`
+- Footer: `relative z-[1]` — do not change this
+
+---
+
+## Task 1: Foundation — constants, variants, delete tailwind shim
+
+**Files:**
+- Modify: `src/lib/constants.ts`
+- Modify: `src/design/variants.ts`
+- Delete: `tailwind.config.ts`
+
+- [ ] **Step 1: Add `SITE_LAUNCH_YEAR` and `PAGE_META` to constants.ts**
+
+Replace the end of `src/lib/constants.ts` (after the existing `API` export) with:
+
+```ts
+// Site launch year — used by footer copyright range
+export const SITE_LAUNCH_YEAR = 2024;
+
+// Per-page SEO metadata — all page metadata exports import from here
+export const PAGE_META = {
+  home: {
+    title: "Hammayo's | Backend Software Engineer",
+    description: 'Portfolio site showcasing 20+ years of backend engineering across finance, justice, and public service.',
+  },
+  about: {
+    title: "About | Hammayo's Portfolio",
+    description: 'Senior backend engineer with 20+ years building distributed systems across finance, justice, and public service.',
+  },
+  blogs: {
+    title: "Blogs | Hammayo's Portfolio",
+    description: 'Technical writing on backend systems, architecture, and engineering craft.',
+  },
+  cv: {
+    title: "CV | Hammayo's Portfolio",
+    description: "Hammy Babar's professional CV and experience.",
+  },
+  projects: {
+    title: "Projects | Hammayo's Portfolio",
+    description: 'Explore my latest projects and open source contributions on GitHub.',
+  },
+  contact: {
+    title: "Contact | Hammayo's Portfolio",
+    description: 'Get in touch via GitHub, LinkedIn, or email.',
+  },
+};
+```
+
+- [ ] **Step 2: Add `ctaButton` CVA variant to `src/design/variants.ts`**
+
+Append to the end of `src/design/variants.ts`:
+
+```ts
+/**
+ * CTA button variant.
+ * Primary uses the scheme gradient background.
+ * Ghost uses a transparent background with border.
+ */
+export const ctaButton = cva(
+  'inline-flex items-center justify-center rounded-lg px-6 py-3 text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        gradient: 'gradient-bg text-white shadow-sm hover:opacity-90 focus-visible:ring-[var(--scheme-from)]',
+        ghost:    'border border-border text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:ring-border',
+      },
+    },
+    defaultVariants: {
+      variant: 'gradient',
+    },
+  }
+);
+```
+
+- [ ] **Step 3: Delete the tailwind.config.ts shim**
+
+```bash
+rm tailwind.config.ts
+```
+
+Run `bun run build` to confirm the build still passes without the shim.
+
+Expected: Build succeeds. If it fails with a Tailwind config resolution error, check `postcss.config.mjs` — it should only reference `@tailwindcss/postcss`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/constants.ts src/design/variants.ts
+git rm tailwind.config.ts
+git commit -m "feat: add PAGE_META + SITE_LAUNCH_YEAR to constants, add ctaButton CVA variant, delete tailwind shim"
+```
+
+---
+
+## Task 2: Content data files
+
+**Files:**
+- Create: `content/cv.ts`
+- Create: `content/about.ts`
+- Create: `content/blogs.ts`
+
+- [ ] **Step 1: Create `content/cv.ts`**
+
+```ts
+// content/cv.ts
+// Single source of truth for CV data.
+// Phase 2: skills filled in, roles/education scaffolded with placeholders.
+// Phase 3+: expand roles and education with real entries.
+import { SOCIAL } from '@/lib/constants';
+
+export const cv = {
+  linkedIn: SOCIAL.linkedin,
+  placeholderText: 'Full CV coming soon — view my LinkedIn profile in the meantime.',
+
+  skills: {
+    languages: ['Go', 'C#', '.NET', 'TypeScript', 'SQL', 'Python'],
+    platforms: ['Azure', 'Kubernetes', 'Docker', 'GitHub Actions', 'AWS'],
+    tools:     ['Kafka', 'Redis', 'PostgreSQL', 'Terraform', 'Grafana'],
+  },
+
+  roles: [
+    {
+      title:   'Senior Backend Engineer', // TODO: replace with real role
+      company: 'HMPPS / MoJ',            // TODO: replace with real company
+      period:  '2020 – present',          // TODO: replace with real period
+      summary: 'Platform infrastructure and microservices.',
+      tags:    ['Go', 'Kubernetes', 'Azure'],
+    },
+  ],
+
+  education: [
+    {
+      institution:   'TODO: University name',  // TODO: replace
+      qualification: 'TODO: Degree',           // TODO: replace
+      year:          2004,                     // TODO: replace
+    },
+  ],
+};
+```
+
+- [ ] **Step 2: Create `content/about.ts`**
+
+```ts
+// content/about.ts
+// All about-page and homepage bio content.
+// Replace every TODO comment before merging to main.
+
+export const about = {
+  name:            'Hammayo Babar',     // Full name — desktop
+  shortName:       'Hammy Babar',       // Short name — mobile (below md breakpoint)
+  tagline:         'Senior Backend Engineer',
+  careerStartYear: 2004,                // Years of experience = currentYear - careerStartYear
+
+  // Homepage bio — first paragraph uses {stardate} and {years} tokens.
+  // {stardate} = YYYYMM.DD computed client-side daily.
+  // {years}    = currentYear - careerStartYear, updates each Jan 1.
+  homepageBioTemplate: "Captain's log, stardate {stardate}: For last {years} years, I've boldly navigated the digital frontier, charting solutions across uncharted sectors—finance's nebulae, justice's asteroid belts, and the bureaucratic wormholes of public service.",
+
+  // Additional static paragraphs shown below the template paragraph on the homepage.
+  homepageBioExtra: [
+    "Armed with a tricorder of Microsoft tech and a starship engineered from micro-services and Docker containers at warp speed, I've allied with Starfleet's HMPPS to dismantle legacy system Borgs and assimilate innovation. My crew? A cross-functional away team, trained in the Vulcan discipline of clean code and the Klingon art of relentless problem-solving.",
+    'Mission priority: To seek out new patterns, elevate civilizations with scalable tech, and ensure no enterprise is left stranded in the alpha quadrant of obsolescence. Engage at will — let\'s pioneer the final frontier of software, where no challenge has gone before. 🖖',
+  ],
+
+  // /about page — longer professional bio. Replace TODO before merging.
+  bio: 'TODO: Replace with your professional bio. A few sentences about your background, the domains you have worked in, and what drives you.',
+
+  sectors:   ['Distributed Systems', 'Platform Engineering', 'FinTech', 'Justice & Public Service', 'Microservices'],
+  philosophy: 'Build for the next engineer, not just the next deadline.',
+
+  // next/image src — prepend basePath in the component.
+  // Falls back to /_hb-logo.png if avatar.jpg is absent.
+  avatarPath: '/images/avatar.jpg',
+};
+```
+
+- [ ] **Step 3: Create `content/blogs.ts`**
+
+```ts
+// content/blogs.ts
+// Phase 2: placeholder config only.
+// Phase 3 adds posts-per-page, tag config, and the MDX pipeline.
+
+export const blogs = {
+  placeholderTitle:       'Blogs',
+  placeholderDescription: 'Technical writing on backend systems, architecture, and engineering craft.',
+  comingSoonMessage:      'Posts coming soon — check back later.',
+  backLinkText:           '← Back to home',
+};
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add content/cv.ts content/about.ts content/blogs.ts
+git commit -m "feat: scaffold content/cv.ts, content/about.ts, content/blogs.ts"
+```
+
+---
+
+## Task 3: Navigation + footer
+
+**Files:**
+- Modify: `src/features/shared/header.tsx`
+- Create: `src/features/shared/copyright-year.tsx`
+- Modify: `src/features/shared/footer.tsx`
+
+- [ ] **Step 1: Update `src/features/shared/header.tsx`**
+
+Replace the entire file. Key changes: add About + Blogs links (order: About · Projects · Blogs · Contact), add mobile hamburger + Sheet nav, preserve logo responsive text and gradient.
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { Menu } from "lucide-react";
+import { Container } from "./container";
+import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
+import { cn } from "@/lib/utils";
+import { basePath } from "@/lib/env";
+
+const NAV_LINKS = [
+  { href: "/about",    label: "About"    },
+  { href: "/projects", label: "Projects" },
+  { href: "/blogs",    label: "Blogs"    },
+  { href: "/contact",  label: "Contact"  },
+] as const;
+
+const gradientClasses =
+  "text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500 font-medium";
+const inactiveClasses =
+  "dark:text-zinc-400 text-zinc-600 hover:text-transparent hover:bg-clip-text hover:bg-gradient-to-r hover:from-purple-500 hover:via-cyan-500 hover:to-green-500";
+
+function NavLink({ href, label, pathname, onClick }: {
+  href: string;
+  label: string;
+  pathname: string;
+  onClick?: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      prefetch
+      onClick={onClick}
+      className={cn(
+        "duration-300 transition-all tracking-tight",
+        pathname === href ? gradientClasses : inactiveClasses
+      )}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function Header() {
+  const pathname  = usePathname();
+  const logoPath  = `${basePath}/images/_hb-logo.png`;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header
+      role="banner"
+      className="fixed top-0 left-0 right-0 z-50 dark:bg-zinc-950/80 bg-white/80 backdrop-blur-xl border-b dark:border-zinc-800/50 border-zinc-200/50"
+    >
+      <Container>
+        <nav role="navigation" aria-label="Main navigation">
+          <div className="flex items-center justify-between py-2">
+            {/* Logo */}
+            <Link
+              href="/"
+              prefetch
+              className="text-base font-semibold tracking-tighter flex items-center gap-2 transition-transform"
+            >
+              <Image
+                src={logoPath}
+                alt="HB"
+                width={28}
+                height={28}
+                priority
+                unoptimized
+                className="animate-float"
+              />
+              <span
+                className="md:inline hidden animate-gradient text-transparent bg-clip-text"
+                style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
+              >Hammayo</span>
+              <span
+                className="md:hidden animate-gradient text-transparent bg-clip-text"
+                style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
+              >Hammy</span>
+            </Link>
+
+            {/* Desktop nav */}
+            <div className="hidden md:flex items-center gap-8">
+              {NAV_LINKS.map(({ href, label }) => (
+                <NavLink key={href} href={href} label={label} pathname={pathname} />
+              ))}
+            </div>
+
+            {/* Mobile hamburger */}
+            <div className="md:hidden">
+              <Sheet open={open} onOpenChange={setOpen}>
+                <SheetTrigger asChild>
+                  <button
+                    aria-label="Open navigation"
+                    className="p-2 rounded-md dark:text-zinc-400 text-zinc-600 hover:text-foreground transition-colors"
+                  >
+                    <Menu className="h-5 w-5" />
+                  </button>
+                </SheetTrigger>
+                <SheetContent side="right" className="w-64 pt-12">
+                  <nav aria-label="Mobile navigation" className="flex flex-col gap-6 mt-4">
+                    {NAV_LINKS.map(({ href, label }) => (
+                      <NavLink
+                        key={href}
+                        href={href}
+                        label={label}
+                        pathname={pathname}
+                        onClick={() => setOpen(false)}
+                      />
+                    ))}
+                  </nav>
+                </SheetContent>
+              </Sheet>
+            </div>
+          </div>
+        </nav>
+      </Container>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 2: Verify Sheet import path**
+
+Check `src/features/shared/ui/sheet.tsx` exists and exports `Sheet`, `SheetContent`, `SheetTrigger`. If the import path differs, adjust the import in the header.
+
+```bash
+grep -n "export" src/features/shared/ui/sheet.tsx | head -10
+```
+
+Expected: Lines containing `export { Sheet`, `SheetContent`, `SheetTrigger`.
+
+- [ ] **Step 3: Create `src/features/shared/copyright-year.tsx`**
+
+```tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface CopyrightYearProps {
+  launchYear: number;
+}
+
+export function CopyrightYear({ launchYear }: CopyrightYearProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const current = new Date().getFullYear();
+
+  if (!mounted) {
+    return <span>{launchYear}</span>;
+  }
+
+  return (
+    <span>{launchYear === current ? current : `${launchYear}–${current}`}</span>
+  );
+}
+```
+
+- [ ] **Step 4: Update `src/features/shared/footer.tsx`**
+
+Replace the copyright line only — swap `{new Date().getUTCFullYear()}` for `<CopyrightYear />`:
+
+```tsx
+import { SITE, SOCIAL, SITE_LAUNCH_YEAR } from "@/lib/constants";
+import { Button } from "@/features/shared/ui/button";
+import { Mail } from "lucide-react";
+import { ThemeToggle } from "./theme-toggle";
+import { CopyrightYear } from "./copyright-year";
+
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  );
+}
+
+function LinkedinIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+export function Footer({ className }: { className?: string }) {
+  return (
+    <footer className={`w-full border-t border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60${className ? ` ${className}` : ''}`}>
+      <div className="container flex items-center justify-between gap-4 py-2">
+        <div className="flex items-center">
+          <p className="text-xs text-muted-foreground">
+            Built by{' '}
+            <a
+              href={SOCIAL.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline underline-offset-4"
+            >
+              {SITE.author}
+            </a>
+            {' '}&copy; <CopyrightYear launchYear={SITE_LAUNCH_YEAR} />
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" asChild>
+            <a href={SOCIAL.github} target="_blank" rel="noopener noreferrer">
+              <GithubIcon className="h-4 w-4" />
+              <span className="sr-only">GitHub</span>
+            </a>
+          </Button>
+          <Button variant="ghost" size="icon" asChild>
+            <a href={SOCIAL.linkedin} target="_blank" rel="noopener noreferrer">
+              <LinkedinIcon className="h-4 w-4" />
+              <span className="sr-only">LinkedIn</span>
+            </a>
+          </Button>
+          <Button variant="ghost" size="icon" asChild>
+            <a href={`mailto:${SOCIAL.email}`}>
+              <Mail className="h-4 w-4" />
+              <span className="sr-only">Email</span>
+            </a>
+          </Button>
+          <div className="ml-2 border-l border-border/40 pl-4">
+            <ThemeToggle aria-label="Toggle color theme" />
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+```
+
+- [ ] **Step 5: Start dev server and verify nav**
+
+```bash
+bun run dev
+```
+
+Open http://localhost:3000. Check:
+- Desktop: About · Projects · Blogs · Contact links visible; active link shows gradient text
+- Mobile (<768px): only hamburger visible; clicking opens Sheet with all 4 links
+- Logo: "Hammayo" on desktop, "Hammy" on mobile
+- Footer: copyright year renders (e.g. `© 2024–2026` or `© 2026` if launch year = current year)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/shared/header.tsx src/features/shared/copyright-year.tsx src/features/shared/footer.tsx
+git commit -m "feat: add mobile sheet nav, About/Blogs links, active link gradient, dynamic copyright year"
+```
+
+---
+
+## Task 4: Homepage expansion
+
+**Files:**
+- Create: `src/features/home/homepage-bio.tsx`
+- Create: `src/features/home/skills-strip.tsx`
+- Create: `src/features/home/cta.tsx`
+- Modify: `src/app/page.tsx`
+
+- [ ] **Step 1: Create `src/features/home/homepage-bio.tsx`**
+
+```tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface HomepageBioProps {
+  template:        string;
+  extra:           string[];
+  careerStartYear: number;
+}
+
+function formatStardate(d: Date): string {
+  const year  = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day   = String(d.getDate()).padStart(2, '0');
+  return `${year}${month}.${day}`;
+}
+
+function interpolate(template: string, values: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) =>
+    key in values ? String(values[key]) : `{${key}}`
+  );
+}
+
+export function HomepageBio({ template, extra, careerStartYear }: HomepageBioProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const stardate = mounted ? formatStardate(new Date()) : '......';
+  const years    = mounted ? new Date().getFullYear() - careerStartYear : '..';
+
+  const firstPara = interpolate(template, { stardate, years });
+
+  return (
+    <div className="text-sm md:text-base text-muted-foreground leading-relaxed tracking-tight space-y-3">
+      <p>{firstPara}</p>
+      {extra.map((para, i) => (
+        <p key={i}>{para}</p>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/features/home/skills-strip.tsx`**
+
+```tsx
+import { accentTag } from '@/design/variants';
+
+interface SkillsStripProps {
+  skills: {
+    languages: string[];
+    platforms: string[];
+    tools:     string[];
+  };
+}
+
+export function SkillsStrip({ skills }: SkillsStripProps) {
+  const all = [...skills.languages, ...skills.platforms, ...skills.tools];
+
+  if (all.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 justify-center">
+      {all.map((skill) => (
+        <span key={skill} className={accentTag()}>
+          {skill}
+        </span>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `src/features/home/cta.tsx`**
+
+```tsx
+import Link from 'next/link';
+import { ctaButton } from '@/design/variants';
+
+export function CTARow() {
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+      <Link href="/projects" className={ctaButton({ variant: 'gradient' })}>
+        View Projects
+      </Link>
+      <Link href="/contact" className={ctaButton({ variant: 'ghost' })}>
+        Get in Touch
+      </Link>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update `src/app/page.tsx`**
+
+Replace the entire file. Removes the old `generateStardate` server function and hardcoded bio string. All content from data files.
+
+```tsx
+import { Container } from "@/features/shared/container";
+import { Hero } from "@/features/home/hero";
+import { HomepageBio } from "@/features/home/homepage-bio";
+import { SkillsStrip } from "@/features/home/skills-strip";
+import { CTARow } from "@/features/home/cta";
+import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { PageViewEvent } from "@/features/shared/analytics-event";
+import { about } from "../../content/about";
+import { cv } from "../../content/cv";
+
+export default function HomePage() {
+  return (
+    <PageTransitionWrapper>
+      <PageViewEvent page="home" />
+      <div className="flex-1 flex flex-col items-center justify-center">
+        <Container className="text-center space-y-8">
+          <div className="opacity-0 animate-fade-in animate-delay-500">
+            <Hero />
+          </div>
+          <div className="opacity-0 animate-fade-in animate-delay-200">
+            <HomepageBio
+              template={about.homepageBioTemplate}
+              extra={about.homepageBioExtra}
+              careerStartYear={about.careerStartYear}
+            />
+          </div>
+          <div className="opacity-0 animate-fade-in animate-delay-300">
+            <SkillsStrip skills={cv.skills} />
+          </div>
+          <div className="opacity-0 animate-fade-in animate-delay-400">
+            <CTARow />
+          </div>
+        </Container>
+      </div>
+    </PageTransitionWrapper>
+  );
+}
+```
+
+- [ ] **Step 5: Verify homepage in dev**
+
+Open http://localhost:3000. Check:
+- Bio shows the Star Trek text with live stardate (today's date in YYYYMM.DD format) and computed years
+- Skills tags render with accent-border style
+- "View Projects" and "Get in Touch" CTA buttons present and link correctly
+- No layout overflow or scrollbar appears
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/home/homepage-bio.tsx src/features/home/skills-strip.tsx src/features/home/cta.tsx src/app/page.tsx
+git commit -m "feat: homepage expansion — dynamic bio, skills strip, CTA row"
+```
+
+---
+
+## Task 5: /about page
+
+**Files:**
+- Create: `src/features/about/about-content.tsx`
+- Create: `src/app/about/page.tsx`
+
+- [ ] **Step 1: Create `src/features/about/about-content.tsx`**
+
+```tsx
+import Image from 'next/image';
+import { gradientText, accentTag } from '@/design/variants';
+import { basePath } from '@/lib/env';
+import imageLoader from '@/lib/imageLoader';
+import type { about as AboutType } from '../../../content/about';
+
+interface AboutContentProps {
+  about: typeof AboutType;
+}
+
+export function AboutContent({ about }: AboutContentProps) {
+  const avatarSrc = `${basePath}${about.avatarPath}`;
+  const fallbackSrc = `${basePath}/_hb-logo.png`;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      {/* Hero row: avatar + name + tagline */}
+      <div className="flex items-start gap-5">
+        <div className="relative flex-shrink-0">
+          <Image
+            loader={imageLoader}
+            src={avatarSrc}
+            alt={about.name}
+            width={80}
+            height={80}
+            className="rounded-full ring-2 ring-[var(--scheme-border)] scheme-glow"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = fallbackSrc;
+            }}
+            unoptimized
+          />
+        </div>
+        <div>
+          <h1 className={gradientText({ size: 'heading' })}>
+            <span className="hidden md:inline animate-gradient"
+              style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
+            >{about.name}</span>
+            <span className="md:hidden animate-gradient"
+              style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
+            >{about.shortName}</span>
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">{about.tagline}</p>
+        </div>
+      </div>
+
+      {/* Bio */}
+      <p className="text-sm md:text-base text-muted-foreground leading-relaxed">{about.bio}</p>
+
+      {/* Sectors */}
+      <div className="space-y-2">
+        <h2 className="text-xs uppercase tracking-widest text-muted-foreground">Sectors & Domains</h2>
+        <div className="flex flex-wrap gap-2">
+          {about.sectors.map((sector) => (
+            <span key={sector} className={accentTag()}>
+              {sector}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Philosophy */}
+      <div className="border-l-2 border-[var(--scheme-border)] pl-4">
+        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-1">Philosophy</p>
+        <p className="text-sm md:text-base italic text-foreground/80">&ldquo;{about.philosophy}&rdquo;</p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/app/about/page.tsx`**
+
+```tsx
+import { Container } from "@/features/shared/container";
+import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { AboutContent } from "@/features/about/about-content";
+import { PageViewEvent } from "@/features/shared/analytics-event";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import type { Metadata } from "next";
+import { about } from "../../../content/about";
+
+export const metadata: Metadata = {
+  title: PAGE_META.about.title,
+  description: PAGE_META.about.description,
+  openGraph: {
+    title: PAGE_META.about.title,
+    description: PAGE_META.about.description,
+    url: `${SITE_URL}/about`,
+  },
+  twitter: {
+    title: PAGE_META.about.title,
+    description: PAGE_META.about.description,
+  },
+};
+
+export default function AboutPage() {
+  return (
+    <PageTransitionWrapper>
+      <PageViewEvent page="about" />
+      <Container>
+        <AboutContent about={about} />
+      </Container>
+    </PageTransitionWrapper>
+  );
+}
+```
+
+- [ ] **Step 3: Verify /about in dev**
+
+Open http://localhost:3000/about. Check:
+- Name shows "Hammayo Babar" on desktop, "Hammy Babar" on mobile
+- Avatar renders (shows logo fallback if `public/images/avatar.jpg` absent — that is expected)
+- Sectors chips show accent border style
+- Philosophy quote renders with left border accent
+- No layout overflow
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/about/about-content.tsx src/app/about/page.tsx
+git commit -m "feat: /about page — compact hero layout, sectors, philosophy, responsive name"
+```
+
+---
+
+## Task 6: /blogs placeholder
+
+**Files:**
+- Modify: `src/app/blogs/page.tsx`
+
+- [ ] **Step 1: Rewrite `src/app/blogs/page.tsx`**
+
+Replace the entire file:
+
+```tsx
+import { Container } from "@/features/shared/container";
+import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { PageViewEvent } from "@/features/shared/analytics-event";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { blogs } from "../../../content/blogs";
+
+export const metadata: Metadata = {
+  title: PAGE_META.blogs.title,
+  description: PAGE_META.blogs.description,
+  openGraph: {
+    title: PAGE_META.blogs.title,
+    description: PAGE_META.blogs.description,
+    url: `${SITE_URL}/blogs`,
+  },
+  twitter: {
+    title: PAGE_META.blogs.title,
+    description: PAGE_META.blogs.description,
+  },
+};
+
+export default function BlogsPage() {
+  return (
+    <PageTransitionWrapper>
+      <PageViewEvent page="blogs" />
+      <Container>
+        <div className="flex flex-col items-center justify-center text-center space-y-6 py-16">
+          <div className="flex items-center gap-3">
+            <h1 className={gradientText({ size: 'heading' })}>{blogs.placeholderTitle}</h1>
+            <span className="text-xs px-3 py-1 rounded-full border border-[var(--scheme-border)] text-[var(--scheme-accent)]">
+              Coming soon
+            </span>
+          </div>
+          <p className="text-muted-foreground max-w-md">{blogs.placeholderDescription}</p>
+          <p className="text-sm text-muted-foreground">{blogs.comingSoonMessage}</p>
+          <Link href="/" className="text-sm text-[var(--scheme-accent)] hover:underline">
+            {blogs.backLinkText}
+          </Link>
+        </div>
+      </Container>
+    </PageTransitionWrapper>
+  );
+}
+```
+
+- [ ] **Step 2: Verify /blogs in dev**
+
+Open http://localhost:3000/blogs. Check:
+- "Blogs" heading renders in gradient text
+- "Coming soon" badge visible
+- Description and back link present
+- No WIP text from old file remains
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/blogs/page.tsx
+git commit -m "feat: /blogs styled placeholder — data-driven from content/blogs.ts"
+```
+
+---
+
+## Task 7: /cv placeholder
+
+**Files:**
+- Create: `src/app/cv/page.tsx`
+
+- [ ] **Step 1: Create `src/app/cv/page.tsx`**
+
+```tsx
+import { Container } from "@/features/shared/container";
+import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { PageViewEvent } from "@/features/shared/analytics-event";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
+import type { Metadata } from "next";
+import { cv } from "../../../content/cv";
+
+export const metadata: Metadata = {
+  title: PAGE_META.cv.title,
+  description: PAGE_META.cv.description,
+  openGraph: {
+    title: PAGE_META.cv.title,
+    description: PAGE_META.cv.description,
+    url: `${SITE_URL}/cv`,
+  },
+  twitter: {
+    title: PAGE_META.cv.title,
+    description: PAGE_META.cv.description,
+  },
+};
+
+export default function CVPage() {
+  return (
+    <PageTransitionWrapper>
+      <PageViewEvent page="cv" />
+      <Container>
+        <div className="flex flex-col items-center justify-center text-center space-y-6 py-16">
+          <div className="flex items-center gap-3">
+            <h1 className={gradientText({ size: 'heading' })}>CV</h1>
+            <span className="text-xs px-3 py-1 rounded-full border border-[var(--scheme-border)] text-[var(--scheme-accent)]">
+              Coming soon
+            </span>
+          </div>
+          <p className="text-muted-foreground max-w-md">{cv.placeholderText}</p>
+          <a
+            href={cv.linkedIn}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-[var(--scheme-accent)] hover:underline"
+          >
+            View LinkedIn Profile →
+          </a>
+        </div>
+      </Container>
+    </PageTransitionWrapper>
+  );
+}
+```
+
+- [ ] **Step 2: Verify /cv in dev**
+
+Open http://localhost:3000/cv. Check:
+- "CV" heading in gradient text with "Coming soon" badge
+- Placeholder text from `content/cv.ts`
+- LinkedIn link opens in new tab with `noopener noreferrer`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/cv/page.tsx
+git commit -m "feat: /cv styled placeholder — LinkedIn link, data-driven from content/cv.ts"
+```
+
+---
+
+## Task 8: /projects redesign
+
+**Files:**
+- Modify: `src/features/projects/project-card.tsx`
+- Modify: `src/app/projects/page.tsx`
+
+- [ ] **Step 1: Update `src/features/projects/project-card.tsx`**
+
+Replace topic tag `className` (line 65–71) to use `accentTag` CVA variant. Add `rel="noopener noreferrer"` to external links. No other structural changes.
+
+```tsx
+"use client";
+
+import { CardContent } from "@/features/shared/ui/card";
+import type { GitHubRepository } from "@/lib/github";
+import { Star, GitFork, ExternalLink } from "lucide-react";
+import { CardEffects, cardBaseClasses } from "@/features/shared/ui/card-effects";
+import { Button } from "@/features/shared/ui/button";
+import { accentTag } from "@/design/variants";
+import { format } from "date-fns";
+
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  );
+}
+
+interface ProjectCardProps {
+  repo: GitHubRepository;
+  index: number;
+  featured?: boolean;
+}
+
+export function ProjectCard({ repo, index, featured = false }: ProjectCardProps) {
+  return (
+    <CardEffects
+      variant={featured ? "featured" : "default"}
+      className={`animate-in fade-in-50 duration-500 delay-${index * 100}`}
+    >
+      <CardContent className={`${cardBaseClasses.contentWrapper} ${
+        featured ? 'min-h-[18rem]' : 'min-h-[16rem]'
+      } flex flex-col`}>
+        <div className="flex-1 flex flex-col">
+          {/* Header */}
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-2">
+              {featured && (
+                <div className="flex items-center gap-1">
+                  <Star className="w-4 h-4 text-amber-600/70 dark:text-amber-400/60" fill="currentColor" />
+                  <span className="text-xs font-medium text-amber-700/70 dark:text-amber-400/60">Featured</span>
+                </div>
+              )}
+              <h3 className="text-lg font-semibold">{repo.name}</h3>
+            </div>
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <Star className="w-4 h-4" />
+                {repo.stargazers_count}
+              </span>
+              <span className="flex items-center gap-1">
+                <GitFork className="w-4 h-4" />
+                {repo.forks_count}
+              </span>
+            </div>
+          </div>
+
+          {/* Description */}
+          <p className="text-sm text-muted-foreground mb-4">{repo.description}</p>
+
+          {/* Topics — scheme-aware accent tags */}
+          {repo.topics.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {repo.topics.map((topic) => (
+                <span key={topic} className={accentTag()}>
+                  {topic}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Footer */}
+          <div className="mt-auto flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {repo.language && (
+                <span className="text-sm text-muted-foreground">{repo.language}</span>
+              )}
+              <span className="text-sm text-muted-foreground">
+                Updated {format(new Date(repo.updated_at), 'MMM d, yyyy')}
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="ghost" size="sm" asChild>
+                <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
+                  <GithubIcon className="w-4 h-4 mr-1" />
+                  Code
+                </a>
+              </Button>
+              {repo.homepage && (
+                <Button variant="ghost" size="sm" asChild>
+                  <a href={repo.homepage} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="w-4 h-4 mr-1" />
+                    Demo
+                  </a>
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </CardEffects>
+  );
+}
+```
+
+- [ ] **Step 2: Update `src/app/projects/page.tsx` — metadata + gradient heading**
+
+Change the `metadata` export and `h1` heading:
+
+```tsx
+// Replace the existing metadata export:
+export const metadata: Metadata = {
+  title: PAGE_META.projects.title,
+  description: PAGE_META.projects.description,
+  openGraph: {
+    title: PAGE_META.projects.title,
+    description: PAGE_META.projects.description,
+    url: `${SITE_URL}/projects`,
+  },
+  twitter: {
+    title: PAGE_META.projects.title,
+    description: PAGE_META.projects.description,
+  },
+};
+```
+
+Add imports at the top:
+```tsx
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
+```
+
+Replace the heading block:
+```tsx
+<div className="mb-6">
+  <h1 className={gradientText({ size: 'heading' })}>Projects</h1>
+  <p className="text-muted-foreground mt-2">Explore my most recent projects and open source contributions.</p>
+</div>
+```
+
+- [ ] **Step 3: Verify /projects in dev**
+
+Open http://localhost:3000/projects. Check:
+- "Projects" heading in gradient text
+- Project topic tags use scheme accent colour (purple/cyan depending on time of day)
+- Cards retain glow effect on hover
+- External links open in new tab
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/projects/project-card.tsx src/app/projects/page.tsx
+git commit -m "feat: /projects — scheme-aware topic tags, gradient heading, updated metadata"
+```
+
+---
+
+## Task 9: /contact redesign
+
+**Files:**
+- Modify: `src/features/contact/contact-card.tsx`
+- Modify: `src/app/contact/page.tsx`
+
+- [ ] **Step 1: Update `src/features/contact/contact-card.tsx`**
+
+Replace hardcoded per-variant colour maps with scheme-aware CSS vars. The title gradient and button gradient now use `gradient-text` and `gradient-bg` utilities.
+
+```tsx
+"use client";
+
+import { type ReactNode } from "react";
+import { CardEffects, cardBaseClasses } from "@/features/shared/ui/card-effects";
+
+interface ContactCardProps {
+  icon:     ReactNode;
+  title:    string;
+  subtitle: string;
+  link:     string;
+  linkText: string;
+}
+
+export function ContactCard({ icon, title, subtitle, link, linkText }: ContactCardProps) {
+  const isExternal = !link.startsWith("mailto:");
+
+  return (
+    <CardEffects>
+      <div className="flex flex-col items-center gap-4 p-8">
+        <div className="w-16 h-16 flex items-center justify-center border rounded-full dark:bg-black/30 bg-white/30 backdrop-blur-md transition-all duration-300 scheme-border group-hover:scheme-glow">
+          {icon}
+        </div>
+        <div className="flex flex-col items-center mt-2">
+          <h3 className="gradient-text text-xl font-medium tracking-tight transition-all duration-300 opacity-80 group-hover:opacity-100">
+            {title}
+          </h3>
+          <span className={`mt-4 text-sm text-center ${cardBaseClasses.description}`}>
+            {subtitle}
+          </span>
+        </div>
+        <a
+          href={link}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noopener noreferrer" : undefined}
+          className={`${cardBaseClasses.button} gradient-bg mt-6 text-white`}
+        >
+          {linkText}
+        </a>
+      </div>
+    </CardEffects>
+  );
+}
+```
+
+- [ ] **Step 2: Update `src/app/contact/page.tsx`** — remove `variant` prop, update metadata, gradient heading
+
+Update the imports:
+```tsx
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
+```
+
+Replace the `metadata` export:
+```tsx
+export const metadata: Metadata = {
+  title: PAGE_META.contact.title,
+  description: PAGE_META.contact.description,
+  openGraph: {
+    title: PAGE_META.contact.title,
+    description: PAGE_META.contact.description,
+    url: `${SITE_URL}/contact`,
+  },
+  twitter: {
+    title: PAGE_META.contact.title,
+    description: PAGE_META.contact.description,
+  },
+};
+```
+
+Replace heading and remove `variant` prop from all three `<ContactCard>` calls:
+```tsx
+<div className="mb-6">
+  <h1 className={gradientText({ size: 'heading' })}>Contact</h1>
+  <p className="text-muted-foreground mt-2">Feel free to reach out through any of these platforms.</p>
+</div>
+```
+
+```tsx
+// GitHub card — remove variant="github"
+<ContactCard
+  icon={/* existing SVG */}
+  title="hammayo"
+  subtitle="GitHub"
+  link={SOCIAL.github}
+  linkText="View Profile"
+/>
+
+// LinkedIn card — remove variant="linkedin"
+<ContactCard
+  icon={/* existing SVG */}
+  title="hammayo"
+  subtitle="LinkedIn"
+  link={SOCIAL.linkedin}
+  linkText="View Profile"
+/>
+
+// Email card — remove variant="email"
+<ContactCard
+  icon={/* existing SVG */}
+  title={SOCIAL.email}
+  subtitle="Email"
+  link={`mailto:${SOCIAL.email}`}
+  linkText="Send Email"
+/>
+```
+
+- [ ] **Step 3: Verify /contact in dev**
+
+Open http://localhost:3000/contact. Check:
+- "Contact" heading in gradient text
+- All three cards use scheme gradient (not hardcoded purple/blue/cyan)
+- Card icon border uses scheme border on hover
+- Buttons use gradient background
+- LinkedIn and GitHub links open in new tab with correct rel attributes
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/contact/contact-card.tsx src/app/contact/page.tsx
+git commit -m "feat: /contact — scheme-aware ContactCard, gradient heading, updated metadata"
+```
+
+---
+
+## Task 10: SEO, sitemap, final checks
+
+**Files:**
+- Modify: `src/app/sitemap.ts`
+- Modify: `docs/superpowers/specs/2026-04-10-website-revamp-design.md`
+
+- [ ] **Step 1: Update `src/app/sitemap.ts`**
+
+Replace the entire file — use `SITE_URL` from constants and add `/about`, `/blogs`, `/cv`:
+
+```ts
+import { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/constants';
+
+export const dynamic = 'force-static';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return [
+    {
+      url: SITE_URL,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/projects`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/blogs`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/cv`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/contact`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+  ];
+}
+```
+
+- [ ] **Step 2: Run full build to confirm static export passes**
+
+```bash
+bun run build
+```
+
+Expected: Build succeeds with no errors. All routes appear in the build output: `/`, `/about`, `/blogs`, `/cv`, `/projects`, `/contact`.
+
+If `tailwind.config.ts` deletion (Task 1) caused issues, check `postcss.config.mjs` still reads:
+```js
+export default { plugins: { '@tailwindcss/postcss': {} } };
+```
+
+- [ ] **Step 3: Run lint**
+
+```bash
+bun run lint
+```
+
+Expected: No errors. Fix any TypeScript or ESLint issues before committing.
+
+- [ ] **Step 4: Update master spec status line**
+
+In `docs/superpowers/specs/2026-04-10-website-revamp-design.md`, update the status line:
+
+```
+**Status:** Phase 1 complete (merged to `develop`) — Phase 2 complete (`feature/phase-2-nav-expansion`) — Phase 3 pending
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/sitemap.ts docs/superpowers/specs/2026-04-10-website-revamp-design.md
+git commit -m "feat: update sitemap with all Phase 2 routes using SITE_URL; mark Phase 2 complete in master spec"
+```
+
+- [ ] **Step 6: Start dev server for final preview**
+
+```bash
+bun run dev
+```
+
+Walk through each route:
+- `/` — hero, bio with live stardate, skills strip, CTA buttons
+- `/about` — avatar (or logo fallback), responsive name, sectors, philosophy
+- `/blogs` — styled placeholder, coming soon badge
+- `/cv` — styled placeholder, LinkedIn link
+- `/projects` — scheme-aware topic tags, gradient heading
+- `/contact` — scheme-aware cards
+
+Verify in both **light** and **dark** mode. Verify at mobile width (< 768px) — hamburger nav, Hammy/HAMMY text.

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -30,9 +30,85 @@ The master spec (`docs/superpowers/specs/2026-04-10-website-revamp-design.md`) s
 
 ---
 
-## 3. Navigation
+## 3. Design System Constraints & Phase 1 Continuity
 
-### 3.1 Nav items
+Phase 2 builds on top of Phase 1's design system. All new components must honour every constraint below — none are optional.
+
+### 3.1 Colour system
+
+All colours come from `useScheme()` and the CSS custom properties it injects on `:root`:
+
+| CSS var | Use |
+|---|---|
+| `var(--scheme-gradient-from/via/to)` | Gradient text, gradient borders |
+| `var(--scheme-glow)` | `box-shadow` on glow cards |
+| `var(--scheme-accent)` | Accent text colour on tags, links |
+
+Components must not hardcode hex values or Tailwind colour classes for scheme-driven colours. The only exception is structural colours (`zinc-900`, `slate-800`, etc.) that are not scheme-dependent.
+
+### 3.2 Three visual patterns — mapping to Phase 2 components
+
+Every new component maps to exactly one of the three patterns from the master spec:
+
+| Pattern | Phase 2 components |
+|---|---|
+| **Gradient text** | Page headings (`/about`, `/blogs`, `/cv`), `about.name`/`shortName`, CTA heading, active nav link |
+| **Glow card** | `ProjectCard`, `ContactCard`, `/about` avatar frame |
+| **Accent border/tag** | Skills strip tags, about sectors chips |
+
+### 3.3 Animated gradient
+
+The 6-stop animated gradient (`#a855f7 → #818cf8 → #38bdf8 → #34d399 → #f472b6 → #a855f7`, `background-size: 400%`, `animate-gradient` keyframe from `globals.css`) is used for:
+- Hero title (exists)
+- Logo name (exists)
+- About name (`about.name` / `about.shortName` spans)
+- All page headings (gradient text, not animated — static `var(--scheme-gradient-*)` is fine here)
+
+Skills strip tags and sector chips use **static** scheme accent colours, not the animated gradient — the animation is reserved for hero/logo/name prominence only.
+
+### 3.4 `design/variants.ts` — CVA configs
+
+All new component variants must be defined in or extend `src/design/variants.ts`. No ad-hoc Tailwind class strings for reusable patterns. Specifically:
+- Tag/chip variant (skills strip, sectors) — add if not present
+- Glow card variant — add if not present
+- Gradient text variant — add if not present
+- Button variants for CTA row (primary gradient, ghost)
+
+### 3.5 `PageTransitionWrapper`
+
+Every new page shell (`/about`, `/blogs`, `/cv`) must wrap its content in `PageTransitionWrapper` with `flex-1 flex flex-col` — the same pattern used by existing pages. Do not use `min-h-screen`, `h-full`, or set `overflow` on page content — these break the contained scroll layout (`h-dvh overflow-hidden` on root, `overflow-y-auto` on `main`).
+
+### 3.6 Layout constraints (must not regress)
+
+These Phase 1 fixes must not be broken by any Phase 2 change:
+
+| Fix | Constraint |
+|---|---|
+| `h-dvh overflow-hidden` on root | Page content must never set its own height/overflow |
+| `relative z-[1]` on `main` and `footer` | Do not introduce new stacking contexts above `z-[1]` |
+| Header `bg-white/80 dark:bg-zinc-950/80` | Must be preserved when adding mobile nav |
+| Compact header height ~45px | Mobile nav Sheet must account for this; progress bar stays at `top-[45px]` |
+| `PageTransitionWrapper` `flex-1 flex flex-col` | No `pt-*`/`pb-*` padding on the wrapper |
+
+### 3.7 Dark mode
+
+Every new component must include `dark:` Tailwind variants for all background, text, and border colours. Verify in both light and dark mode before marking any task complete.
+
+### 3.8 Reduced motion
+
+No new CSS animations or transitions may be introduced without a `prefers-reduced-motion: reduce` consideration. The `SchemeProvider` already handles scheme transitions. For any new component-level animation (hover effects, entrance animations), either:
+- Use `motion-safe:` Tailwind prefix, or
+- Check `prefers-reduced-motion` via `SchemeProvider` context before animating
+
+### 3.9 Active nav link
+
+The master spec specifies gradient text for the active nav link. Phase 2 is the first time all routes exist, making this implementable. Use `usePathname()` in the header to apply the gradient text class to the matching link. This is a `'use client'` addition to the header — isolate it in a `<NavLinks />` client component rather than making the entire header a client component.
+
+---
+
+## 4. Navigation
+
+### 4.1 Nav items
 
 | Label | Route | Type |
 |---|---|---|
@@ -43,11 +119,11 @@ The master spec (`docs/superpowers/specs/2026-04-10-website-revamp-design.md`) s
 
 No CV link in nav. No Uses page. CV is a standalone placeholder route only (linked from elsewhere if needed).
 
-### 3.2 Desktop nav
+### 4.2 Desktop nav
 
 Existing inline nav in `src/features/shared/header.tsx` — link order updated to: About · Projects · Blogs · Contact. No structural changes.
 
-### 3.3 Logo name — responsive text (preserve from Phase 1)
+### 4.3 Logo name — responsive text (preserve from Phase 1)
 
 The header logo name uses CSS-only responsive text delivered in Phase 1:
 
@@ -61,7 +137,7 @@ The header logo name uses CSS-only responsive text delivered in Phase 1:
 
 Both spans carry the animated gradient — no JS, no `useEffect`, no hydration flash. **Phase 2 header modifications must not break or remove this pattern.**
 
-### 3.4 Mobile nav
+### 4.4 Mobile nav
 
 Below `md` breakpoint: hamburger icon (Lucide `Menu`) replaces inline links. Opens a Radix `Sheet` (already available in `src/features/shared/ui/`) sliding from the right, containing the same 4 links.
 
@@ -72,7 +148,11 @@ Below `md` breakpoint: hamburger icon (Lucide `Menu`) replaces inline links. Ope
 
 No new dependencies required.
 
-### 3.4 `/blogs` as canonical route
+### 4.5 Active nav link
+
+`<NavLinks />` is a `'use client'` component that wraps all nav links and uses `usePathname()` to apply gradient text to the active route. Isolating this as a client component keeps the header shell as a server component. Both desktop and mobile Sheet nav use `<NavLinks />`.
+
+### 4.6 `/blogs` as canonical route
 
 `/blogs` (plural) is the canonical blog entry point — consistent with `/projects` (plural). `src/app/blogs/page.tsx` is rewritten as a styled placeholder (not deleted, not a redirect). There is no `/blog` route.
 
@@ -329,6 +409,9 @@ All `target="_blank"` links (LinkedIn, any external href) must include `rel="noo
 | Action | File | Notes |
 |---|---|---|
 | Modify | `src/features/shared/header.tsx` | Mobile hamburger + Sheet nav, updated link order |
+| Create | `src/features/shared/nav-links.tsx` | Client component — `usePathname()` active link gradient |
+| Modify | `src/design/variants.ts` | Add tag/chip, glow card, gradient text, button CVA variants |
+| Delete | `tailwind.config.ts` | Empty shim deferred from Phase 1 — safe to remove now |
 | Modify | `src/app/page.tsx` | Wire homepage sections |
 | Modify | `src/features/home/hero.tsx` | Unchanged structurally — verify scheme wiring |
 | Create | `src/features/home/homepage-bio.tsx` | Client component — dynamic stardate + years |

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -1,0 +1,284 @@
+# Phase 2: Nav Expansion & Pages — Design Spec
+
+**Date:** 2026-04-10
+**Branch:** `feature/phase-2-nav-expansion` (from `develop`)
+**Status:** Spec approved — implementation plan pending
+**Phase order:** Phase 2 of 3 — Pages & Navigation (was Plan 3 in original spec; swapped with Blog pipeline to deliver visible pages sooner)
+**Depends on:** Phase 1 complete (`feature/phase-1-foundation-upgrade` merged to `develop`)
+
+---
+
+## 1. Goals
+
+Deliver all navigable pages and the full navigation structure. After this phase, the site has a complete shell: every route in the nav exists and is polished. Blog content pipeline (Phase 3) fills in the remaining placeholder.
+
+---
+
+## 2. Phase Order Change
+
+The original `2026-04-10-website-revamp-design.md` had:
+- Plan 2 = Blog & MDX pipeline
+- Plan 3 = Pages & Navigation
+
+**This is now reversed:**
+- **Phase 2 = Pages & Navigation** (this spec)
+- **Phase 3 = Blog & MDX pipeline**
+
+Rationale: pages are independently deliverable without the blog pipeline. Getting the full nav and all pages live first gives a complete, shippable site sooner.
+
+The master spec (`docs/superpowers/specs/2026-04-10-website-revamp-design.md`) status line should be updated to reflect this.
+
+---
+
+## 3. Navigation
+
+### 3.1 Nav items
+
+| Label | Route | Type |
+|---|---|---|
+| About | `/about` | Internal |
+| Projects | `/projects` | Internal |
+| Blogs | `/blogs` | Internal |
+| Contact | `/contact` | Internal |
+
+No CV link in nav. No Uses page. CV is a standalone placeholder route only (linked from elsewhere if needed).
+
+### 3.2 Desktop nav
+
+Existing inline nav in `src/features/shared/header.tsx` — link order updated to: About · Projects · Blogs · Contact. No structural changes.
+
+### 3.3 Mobile nav
+
+Below `md` breakpoint: hamburger icon (Lucide `Menu`) replaces inline links. Opens a Radix `Sheet` (already available in `src/features/shared/ui/`) sliding from the right, containing the same 4 links.
+
+**Accessibility requirements:**
+- Hamburger `<button>` must have `aria-label="Open navigation"`
+- Sheet close button must have `aria-label="Close navigation"`
+- Radix `Sheet` handles focus trap and keyboard navigation automatically
+
+No new dependencies required.
+
+### 3.4 `/blogs` as canonical route
+
+`/blogs` (plural) is the canonical blog entry point — consistent with `/projects` (plural). `src/app/blogs/page.tsx` is rewritten as a styled placeholder (not deleted, not a redirect). There is no `/blog` route.
+
+---
+
+## 4. Homepage Expansion
+
+Sections in order — all content from data files, no hardcoded strings in the component:
+
+1. **Hero** — exists from Phase 1 (`src/features/home/hero.tsx`)
+2. **Bio** — `{about.homepageBio}` from `content/about.ts` (Star Trek bio)
+3. **Skills strip** — `{cv.skills}` from `content/cv.ts` — accent-border tags via `useScheme()`; renders nothing if skills array is empty (no broken layout)
+4. **CTA row** — "View Projects" (gradient button → `/projects`) + "Get in Touch" (ghost button → `/contact`)
+
+No blog preview section — deferred to Phase 3 when the content pipeline exists.
+
+---
+
+## 5. Content Data Files
+
+All page content lives in typed TypeScript files under `content/`. Pages are pure renderers — no hardcoded strings. Author edits the data file; the page, metadata, and OG tags update everywhere.
+
+### `content/about.ts`
+
+```ts
+export const about = {
+  name: string,               // "Hammy Babar"
+  tagline: string,            // "Senior Backend Engineer · 20 years"
+  homepageBio: string,        // Star Trek bio — shown on homepage
+  bio: string,                // Longer professional bio — shown on /about
+  sectors: string[],          // ["Distributed Systems", "Platform Eng", "FinTech", ...]
+  philosophy: string,         // Quoted philosophy line
+  avatarPath: string,         // "/images/avatar.jpg" — falls back to "/_hb-logo.png" in component
+};
+```
+
+`linkedIn` is not duplicated here — import from `content/cv.ts` wherever a LinkedIn URL is needed. Single source of truth.
+
+Scaffold with clearly marked `// TODO: replace` placeholders so the page renders on first deploy without exposing bare placeholder text publicly. Author replaces before merging to main.
+
+### `content/cv.ts`
+
+```ts
+export const cv = {
+  linkedIn: string,           // Full LinkedIn profile URL (used by /cv placeholder)
+  placeholderText: string,    // "Full CV coming soon — view my LinkedIn in the meantime."
+  skills: {
+    languages: string[],
+    platforms: string[],
+    tools: string[],
+  },
+  roles: Array<{
+    title: string,
+    company: string,
+    period: string,
+    summary: string,
+    tags: string[],
+  }>,
+  education: Array<{
+    institution: string,
+    qualification: string,
+    year: number,
+  }>,
+};
+```
+
+`roles` and `education` are scaffolded with placeholder entries for Phase 2. The skills arrays are filled in — they power the homepage skills strip.
+
+### `content/blogs.ts`
+
+```ts
+export const blogs = {
+  placeholderTitle: string,    // "Blog"
+  placeholderDescription: string, // "Technical writing on backend systems..."
+  comingSoonMessage: string,   // "Posts coming soon — check back later."
+};
+```
+
+Phase 3 extends this file with pipeline config (posts-per-page, tag list, etc.).
+
+### `src/lib/constants.ts` — page metadata config
+
+Per-page SEO metadata added alongside the existing `SITE_URL`:
+
+```ts
+export const PAGE_META = {
+  home:     { title: '...', description: '...' },
+  about:    { title: '...', description: '...' },
+  blogs:    { title: '...', description: '...' },
+  cv:       { title: '...', description: '...' },
+  projects: { title: '...', description: '...' },
+  contact:  { title: '...', description: '...' },
+};
+```
+
+All `export const metadata` in page files import from `PAGE_META` — no hardcoded title strings in page components.
+
+---
+
+## 6. Pages
+
+### 6.1 `/about`
+
+**Layout:** Compact hero — avatar + name + tagline at top, sector chips below, philosophy as a quoted callout (`border-left` accent).
+
+**Avatar:** `next/image` with the existing `imageLoader` (required for GitHub Pages static export). `src={about.avatarPath}` with `onError` fallback to `/_hb-logo.png`.
+
+**Data:** `content/about.ts`
+
+**Files:**
+- `src/app/about/page.tsx` — thin shell, `metadata` from `PAGE_META.about`
+- `src/features/about/about-content.tsx` — layout component, receives `about` as prop
+
+### 6.2 `/blogs`
+
+**Type:** Styled placeholder
+
+**Content:** All text from `content/blogs.ts` — title, description, coming-soon message, back link text.
+
+**Style:** Matches site design — gradient title, "Coming soon" badge, short description, back-to-home link.
+
+**File:** `src/app/blogs/page.tsx` — rewritten from old redirect stub. Inline component (no feature directory needed for a placeholder).
+
+### 6.3 `/cv`
+
+**Type:** Styled placeholder with LinkedIn link
+
+**Content:** All text from `content/cv.ts` — `placeholderText`, `linkedIn` URL.
+
+**External link:** `target="_blank" rel="noopener noreferrer"` on the LinkedIn anchor (enforced as a rule for all external links site-wide).
+
+**File:** `src/app/cv/page.tsx` — new, inline component.
+
+### 6.4 `/projects` (redesigned)
+
+Same GitHub API data source. `ProjectCard` updated to scheme-aware glow card (`box-shadow` from `useScheme().glow`). No data model changes.
+
+**Files:**
+- `src/features/projects/project-card.tsx` — glow card treatment
+- `src/app/projects/page.tsx` — `metadata` from `PAGE_META.projects`
+
+### 6.5 `/contact` (redesigned)
+
+Same data. `ContactCard` updated to scheme-aware glow card. No data model changes.
+
+**Files:**
+- `src/features/contact/contact-card.tsx` — glow card treatment
+- `src/app/contact/page.tsx` — `metadata` from `PAGE_META.contact`
+
+---
+
+## 7. SEO
+
+### 7.1 Metadata
+
+All pages export `metadata` sourced from `PAGE_META` in `constants.ts`. No hardcoded title strings in page files. Includes `title`, `description`, `openGraph`, and `twitter` fields. OG images point to the existing default — no per-page OG image generation in Phase 2 (Phase 3 scope for blog posts).
+
+### 7.2 Sitemap
+
+`src/app/sitemap.ts` updated to include `/about`, `/blogs`, `/cv`. All routes are statically exportable — no `generateStaticParams` required (no dynamic segments in Phase 2).
+
+### 7.3 robots.txt
+
+No changes — all new pages are public.
+
+---
+
+## 8. External Links
+
+All `target="_blank"` links (LinkedIn, any external href) must include `rel="noopener noreferrer"`. This is a site-wide rule, not component-specific. Applies to: `/cv` placeholder LinkedIn link, `/about` LinkedIn link if shown, any project links in project cards.
+
+---
+
+## 9. File Map
+
+| Action | File | Notes |
+|---|---|---|
+| Modify | `src/features/shared/header.tsx` | Mobile hamburger + Sheet nav, updated link order |
+| Modify | `src/app/page.tsx` | Wire homepage sections |
+| Modify | `src/features/home/hero.tsx` | Unchanged structurally — verify scheme wiring |
+| Create | `src/features/home/skills-strip.tsx` | Reads `content/cv.ts`, scheme-aware tags |
+| Create | `src/features/home/cta.tsx` | "View Projects" + "Get in Touch" |
+| Create | `content/cv.ts` | Typed CV data — skills filled, roles scaffolded |
+| Create | `content/about.ts` | Bio, homepageBio, sectors, philosophy, avatarPath, linkedIn |
+| Create | `content/blogs.ts` | Placeholder config |
+| Modify | `src/lib/constants.ts` | Add `PAGE_META` per-page metadata config |
+| Create | `src/app/about/page.tsx` | Thin shell with metadata |
+| Create | `src/features/about/about-content.tsx` | Compact hero layout |
+| Modify | `src/app/blogs/page.tsx` | Rewrite as styled placeholder |
+| Create | `src/app/cv/page.tsx` | Styled placeholder + LinkedIn link |
+| Modify | `src/features/projects/project-card.tsx` | Scheme-aware glow card |
+| Modify | `src/app/projects/page.tsx` | Update metadata |
+| Modify | `src/features/contact/contact-card.tsx` | Scheme-aware glow card |
+| Modify | `src/app/contact/page.tsx` | Update metadata |
+| Modify | `src/app/sitemap.ts` | Add `/about`, `/blogs`, `/cv` |
+| Modify | `docs/superpowers/specs/2026-04-10-website-revamp-design.md` | Update status + phase order |
+
+---
+
+## 10. Implementation Order
+
+Tasks run sequentially within the plan:
+
+1. **Nav** — header mobile sheet + link order (unblocks all visual QA)
+2. **Homepage expansion** — skills strip + CTA (requires `content/cv.ts`)
+3. **Content scaffolds** — `content/cv.ts`, `content/about.ts`, `content/blogs.ts`, `PAGE_META`
+4. **`/about` page** — shell + feature component
+5. **`/blogs` + `/cv` placeholders** — styled, data-driven
+6. **`/projects` + `/contact` redesign** — glow card treatment
+7. **SEO** — sitemap, metadata review pass
+8. **Master spec update** — reflect phase reorder
+
+---
+
+## 11. Out of Scope
+
+- Blog MDX pipeline, post rendering, tag filtering (Phase 3)
+- Full CV timeline page (future — beyond Phase 3)
+- `/uses` page (removed entirely)
+- OG image generation (Phase 3)
+- RSS feed, sitemap blog slug extension (Phase 3)
+- New dependencies beyond Phase 1 stack
+- Test infrastructure

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -1,4 +1,4 @@
-ThThe# Phase 2: Nav Expansion & Pages — Design Spec
+ThTheDo # Phase 2: Nav Expansion & Pages — Design Spec
 
 **Date:** 2026-04-10
 **Branch:** `feature/phase-2-nav-expansion` (from `develop`)
@@ -130,7 +130,8 @@ All page content lives in typed TypeScript files under `content/`. Pages are pur
 
 ```ts
 export const about = {
-  name: string,                    // "Hammy Babar"
+  name: string,                    // "Hammayo Babar" — full name, shown on desktop
+  shortName: string,               // "Hammy Babar" — shown on mobile (below md breakpoint)
   tagline: string,                 // "Senior Backend Engineer"
   careerStartYear: number,         // e.g. 2004 — years of experience auto-computed from this
   homepageBioTemplate: string,     // "Captain's log, stardate {stardate}: For last {years} years..."
@@ -215,6 +216,18 @@ All `export const metadata` in page files import from `PAGE_META` — no hardcod
 ### 6.1 `/about`
 
 **Layout:** Compact hero — avatar + name + tagline at top, sector chips below, philosophy as a quoted callout (`border-left` accent).
+
+**Responsive name — CSS-only (same pattern as logo and hero):**
+
+```tsx
+<span className="hidden md:inline">{about.name}</span>
+<span className="md:hidden">{about.shortName}</span>
+```
+
+- Desktop (`md`+): `about.name` — e.g. "Hammayo Babar"
+- Mobile (below `md`): `about.shortName` — e.g. "Hammy Babar"
+
+No JS, no `useEffect`, no hydration flash. Both spans carry the gradient text style. Consistent with the logo and hero title pattern across the site.
 
 **Avatar:** `next/image` with the existing `imageLoader` (required for GitHub Pages static export). `src={about.avatarPath}` with `onError` fallback to `/_hb-logo.png`.
 

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -1,4 +1,4 @@
-Th# Phase 2: Nav Expansion & Pages — Design Spec
+ThThe# Phase 2: Nav Expansion & Pages — Design Spec
 
 **Date:** 2026-04-10
 **Branch:** `feature/phase-2-nav-expansion` (from `develop`)
@@ -177,9 +177,11 @@ Phase 3 extends this file with pipeline config (posts-per-page, tag list, etc.).
 
 ### `src/lib/constants.ts` — page metadata config
 
-Per-page SEO metadata added alongside the existing `SITE_URL`:
+Per-page SEO metadata and site-wide constants added alongside the existing `SITE_URL`:
 
 ```ts
+export const SITE_LAUNCH_YEAR = 2024; // Used by footer copyright range
+
 export const PAGE_META = {
   home:     { title: '...', description: '...' },
   about:    { title: '...', description: '...' },
@@ -244,6 +246,33 @@ Same data. `ContactCard` updated to scheme-aware glow card. No data model change
 - `src/features/contact/contact-card.tsx` — glow card treatment
 - `src/app/contact/page.tsx` — `metadata` from `PAGE_META.contact`
 
+### 6.6 Footer — dynamic copyright year
+
+The footer currently has `© 2026` hardcoded. This must update automatically on 1 Jan each year **without a rebuild or redeployment** — i.e. it must be client-side computed.
+
+**Implementation:** A tiny `<CopyrightYear />` client component replaces the hardcoded year. The footer itself remains a server component — only the year span is isolated as a client island.
+
+```tsx
+// src/features/shared/copyright-year.tsx
+'use client'
+export function CopyrightYear({ launchYear }: { launchYear: number }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const current = new Date().getFullYear();
+  if (!mounted) return <span>{launchYear}</span>;
+  return <span>{launchYear === current ? current : `${launchYear}–${current}`}</span>;
+}
+```
+
+Footer renders: `© <CopyrightYear launchYear={SITE_LAUNCH_YEAR} /> Hammy Babar`
+
+- In launch year: `© 2024 Hammy Babar`
+- Subsequent years: `© 2024–2026 Hammy Babar`
+- `SITE_LAUNCH_YEAR` lives in `src/lib/constants.ts` — one edit sets it permanently
+
+**File:** `src/features/shared/copyright-year.tsx` — new, tiny client component
+**Modify:** `src/features/shared/footer.tsx` — swap hardcoded year for `<CopyrightYear />`
+
 ---
 
 ## 7. SEO
@@ -279,7 +308,7 @@ All `target="_blank"` links (LinkedIn, any external href) must include `rel="noo
 | Create | `src/features/home/skills-strip.tsx` | Reads `content/cv.ts`, scheme-aware tags |
 | Create | `src/features/home/cta.tsx` | "View Projects" + "Get in Touch" |
 | Create | `content/cv.ts` | Typed CV data — skills filled, roles scaffolded |
-| Create | `content/about.ts` | Bio, homepageBio, sectors, philosophy, avatarPath, linkedIn |
+| Create | `content/about.ts` | Bio, homepageBioTemplate, careerStartYear, sectors, philosophy, avatarPath |
 | Create | `content/blogs.ts` | Placeholder config |
 | Modify | `src/lib/constants.ts` | Add `PAGE_META` per-page metadata config |
 | Create | `src/app/about/page.tsx` | Thin shell with metadata |
@@ -290,6 +319,9 @@ All `target="_blank"` links (LinkedIn, any external href) must include `rel="noo
 | Modify | `src/app/projects/page.tsx` | Update metadata |
 | Modify | `src/features/contact/contact-card.tsx` | Scheme-aware glow card |
 | Modify | `src/app/contact/page.tsx` | Update metadata |
+| Create | `src/features/shared/copyright-year.tsx` | Client component — dynamic year range |
+| Modify | `src/features/shared/footer.tsx` | Swap hardcoded year for `<CopyrightYear />` |
+| Modify | `src/lib/constants.ts` | Add `SITE_LAUNCH_YEAR` |
 | Modify | `src/app/sitemap.ts` | Add `/about`, `/blogs`, `/cv` |
 | Modify | `docs/superpowers/specs/2026-04-10-website-revamp-design.md` | Update status + phase order |
 

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -1,4 +1,4 @@
-# Phase 2: Nav Expansion & Pages — Design Spec
+Th# Phase 2: Nav Expansion & Pages — Design Spec
 
 **Date:** 2026-04-10
 **Branch:** `feature/phase-2-nav-expansion` (from `develop`)
@@ -69,9 +69,40 @@ No new dependencies required.
 Sections in order — all content from data files, no hardcoded strings in the component:
 
 1. **Hero** — exists from Phase 1 (`src/features/home/hero.tsx`)
-2. **Bio** — `{about.homepageBio}` from `content/about.ts` (Star Trek bio)
+2. **Bio** — Star Trek bio rendered by `<HomepageBio />` (client component) — see dynamic token spec below
 3. **Skills strip** — `{cv.skills}` from `content/cv.ts` — accent-border tags via `useScheme()`; renders nothing if skills array is empty (no broken layout)
 4. **CTA row** — "View Projects" (gradient button → `/projects`) + "Get in Touch" (ghost button → `/contact`)
+
+### 4.1 `<HomepageBio />` — dynamic Star Trek bio
+
+The bio contains two client-side dynamic values:
+
+- **Stardate** — computed from `new Date()` on the client, formatted as `YYYYMM.DD` (e.g. `202602.07`). Changes each day automatically.
+- **Years of experience** — `new Date().getFullYear() - about.careerStartYear`. Updates automatically on 1 Jan each year without any content edit.
+
+`content/about.ts` stores the bio as a **template string** with named tokens:
+
+```ts
+homepageBioTemplate: "Captain's log, stardate {stardate}: For last {years} years..."
+```
+
+The `<HomepageBio />` component replaces `{stardate}` and `{years}` at render time. It is a `'use client'` component using the `mounted` guard pattern (same as `SchemeProvider`) to prevent SSR/hydration mismatches — on the server pass, tokens are rendered as empty strings or a neutral fallback; after mount, the real values hydrate in.
+
+```tsx
+// src/features/home/homepage-bio.tsx
+'use client'
+export function HomepageBio({ template, careerStartYear }: Props) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const stardate = mounted ? formatStardate(new Date()) : '......';
+  const years    = mounted ? new Date().getFullYear() - careerStartYear : '..';
+
+  return <p>{interpolate(template, { stardate, years })}</p>;
+}
+```
+
+`formatStardate` and `interpolate` are pure functions — unit-testable, no side effects.
 
 No blog preview section — deferred to Phase 3 when the content pipeline exists.
 
@@ -85,17 +116,22 @@ All page content lives in typed TypeScript files under `content/`. Pages are pur
 
 ```ts
 export const about = {
-  name: string,               // "Hammy Babar"
-  tagline: string,            // "Senior Backend Engineer · 20 years"
-  homepageBio: string,        // Star Trek bio — shown on homepage
-  bio: string,                // Longer professional bio — shown on /about
-  sectors: string[],          // ["Distributed Systems", "Platform Eng", "FinTech", ...]
-  philosophy: string,         // Quoted philosophy line
-  avatarPath: string,         // "/images/avatar.jpg" — falls back to "/_hb-logo.png" in component
+  name: string,                    // "Hammy Babar"
+  tagline: string,                 // "Senior Backend Engineer"
+  careerStartYear: number,         // e.g. 2004 — years of experience auto-computed from this
+  homepageBioTemplate: string,     // "Captain's log, stardate {stardate}: For last {years} years..."
+                                   // {stardate} = YYYYMM.DD (client-side, updates daily)
+                                   // {years}    = currentYear - careerStartYear (updates each Jan 1)
+  bio: string,                     // Longer professional bio — shown on /about
+  sectors: string[],               // ["Distributed Systems", "Platform Eng", "FinTech", ...]
+  philosophy: string,              // Quoted philosophy line
+  avatarPath: string,              // "/images/avatar.jpg" — falls back to "/_hb-logo.png"
 };
 ```
 
 `linkedIn` is not duplicated here — import from `content/cv.ts` wherever a LinkedIn URL is needed. Single source of truth.
+
+**`tagline` no longer hardcodes years** — e.g. `"Senior Backend Engineer"` not `"Senior Backend Engineer · 20 years"`. The years figure is computed dynamically by `<HomepageBio />` from `careerStartYear`.
 
 Scaffold with clearly marked `// TODO: replace` placeholders so the page renders on first deploy without exposing bare placeholder text publicly. Author replaces before merging to main.
 
@@ -239,6 +275,7 @@ All `target="_blank"` links (LinkedIn, any external href) must include `rel="noo
 | Modify | `src/features/shared/header.tsx` | Mobile hamburger + Sheet nav, updated link order |
 | Modify | `src/app/page.tsx` | Wire homepage sections |
 | Modify | `src/features/home/hero.tsx` | Unchanged structurally — verify scheme wiring |
+| Create | `src/features/home/homepage-bio.tsx` | Client component — dynamic stardate + years |
 | Create | `src/features/home/skills-strip.tsx` | Reads `content/cv.ts`, scheme-aware tags |
 | Create | `src/features/home/cta.tsx` | "View Projects" + "Get in Touch" |
 | Create | `content/cv.ts` | Typed CV data — skills filled, roles scaffolded |

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -47,7 +47,21 @@ No CV link in nav. No Uses page. CV is a standalone placeholder route only (link
 
 Existing inline nav in `src/features/shared/header.tsx` — link order updated to: About · Projects · Blogs · Contact. No structural changes.
 
-### 3.3 Mobile nav
+### 3.3 Logo name — responsive text (preserve from Phase 1)
+
+The header logo name uses CSS-only responsive text delivered in Phase 1:
+
+```tsx
+<span className="hidden md:inline">Hammayo</span>
+<span className="md:hidden">Hammy</span>
+```
+
+- Desktop (`md` and above): **Hammayo**
+- Mobile (below `md`): **Hammy**
+
+Both spans carry the animated gradient — no JS, no `useEffect`, no hydration flash. **Phase 2 header modifications must not break or remove this pattern.**
+
+### 3.4 Mobile nav
 
 Below `md` breakpoint: hamburger icon (Lucide `Menu`) replaces inline links. Opens a Radix `Sheet` (already available in `src/features/shared/ui/`) sliding from the right, containing the same 4 links.
 
@@ -68,7 +82,7 @@ No new dependencies required.
 
 Sections in order — all content from data files, no hardcoded strings in the component:
 
-1. **Hero** — exists from Phase 1 (`src/features/home/hero.tsx`)
+1. **Hero** — exists from Phase 1 (`src/features/home/hero.tsx`). Contains CSS-only responsive title text — desktop shows **HAMMAYO**, mobile shows **HAMMY** — same `hidden md:inline` / `md:hidden` pattern as the logo. No JS, no hydration flash. Must be preserved unchanged.
 2. **Bio** — Star Trek bio rendered by `<HomepageBio />` (client component) — see dynamic token spec below
 3. **Skills strip** — `{cv.skills}` from `content/cv.ts` — accent-border tags via `useScheme()`; renders nothing if skills array is empty (no broken layout)
 4. **CTA row** — "View Projects" (gradient button → `/projects`) + "Get in Touch" (ghost button → `/contact`)

--- a/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
+++ b/docs/superpowers/specs/2026-04-10-phase-2-nav-expansion-design.md
@@ -2,7 +2,7 @@ ThTheDo # Phase 2: Nav Expansion & Pages — Design Spec
 
 **Date:** 2026-04-10
 **Branch:** `feature/phase-2-nav-expansion` (from `develop`)
-**Status:** Spec approved — implementation plan pending
+**Status:** ✅ Implementation complete — see `docs/superpowers/plans/2026-04-11-phase-2-nav-expansion.md` for full delivery summary and deviations
 **Phase order:** Phase 2 of 3 — Pages & Navigation (was Plan 3 in original spec; swapped with Blog pipeline to deliver visible pages sooner)
 **Depends on:** Phase 1 complete (`feature/phase-1-foundation-upgrade` merged to `develop`)
 
@@ -87,7 +87,7 @@ These Phase 1 fixes must not be broken by any Phase 2 change:
 | `h-dvh overflow-hidden` on root | Page content must never set its own height/overflow |
 | `relative z-[1]` on `main` and `footer` | Do not introduce new stacking contexts above `z-[1]` |
 | Header `bg-white/80 dark:bg-zinc-950/80` | Must be preserved when adding mobile nav |
-| Compact header height ~45px | Mobile nav Sheet must account for this; progress bar stays at `top-[45px]` |
+| Compact header height ~45px | Mobile nav Sheet must account for this; ~~progress bar stays at `top-[45px]`~~ **→ progress bar moved inside `<Header>` as `absolute bottom-0` (layout-agnostic, implemented in Phase 2 polish)** |
 | `PageTransitionWrapper` `flex-1 flex flex-col` | No `pt-*`/`pb-*` padding on the wrapper |
 
 ### 3.7 Dark mode

--- a/docs/superpowers/specs/2026-04-10-website-revamp-design.md
+++ b/docs/superpowers/specs/2026-04-10-website-revamp-design.md
@@ -1,7 +1,7 @@
 # Website Revamp Design Spec
 
 **Date:** 2026-04-10  
-**Status:** Phase 1 complete (merged to `develop`) — Phase 2 in progress (`feature/phase-2-nav-expansion`) — Phase 3 pending
+**Status:** Phase 1 complete (merged to `develop`) — Phase 2 complete (`feature/phase-2-nav-expansion`) — Phase 3 pending
 **Phase order (revised 2026-04-10):** Phase 2 = Pages & Navigation | Phase 3 = Blog & MDX pipeline (swapped from original Plan 2/3 order)  
 **Site:** hammayo.co.uk (GitHub Pages, Next.js static export)
 

--- a/docs/superpowers/specs/2026-04-10-website-revamp-design.md
+++ b/docs/superpowers/specs/2026-04-10-website-revamp-design.md
@@ -1,7 +1,8 @@
 # Website Revamp Design Spec
 
 **Date:** 2026-04-10  
-**Status:** Plan 1 complete (branch `feature/plan-1-foundation`) — Plans 2 & 3 pending  
+**Status:** Phase 1 complete (merged to `develop`) — Phase 2 in progress (`feature/phase-2-nav-expansion`) — Phase 3 pending
+**Phase order (revised 2026-04-10):** Phase 2 = Pages & Navigation | Phase 3 = Blog & MDX pipeline (swapped from original Plan 2/3 order)  
 **Site:** hammayo.co.uk (GitHub Pages, Next.js static export)
 
 ---

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,30 @@
+import { Container } from "@/features/shared/container";
+import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { AboutContent } from "@/features/about/about-content";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import type { Metadata } from "next";
+import { about } from "../../../content/about";
+
+export const metadata: Metadata = {
+  title: PAGE_META.about.title,
+  description: PAGE_META.about.description,
+  openGraph: {
+    title: PAGE_META.about.title,
+    description: PAGE_META.about.description,
+    url: `${SITE_URL}/about`,
+  },
+  twitter: {
+    title: PAGE_META.about.title,
+    description: PAGE_META.about.description,
+  },
+};
+
+export default function AboutPage() {
+  return (
+    <PageTransitionWrapper>
+      <Container>
+        <AboutContent about={about} />
+      </Container>
+    </PageTransitionWrapper>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@ import { Container } from "@/features/shared/container";
 import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
 import { AboutContent } from "@/features/about/about-content";
 import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
 import type { Metadata } from "next";
 import { about } from "../../../content/about";
 
@@ -23,6 +24,10 @@ export default function AboutPage() {
   return (
     <PageTransitionWrapper>
       <Container>
+        <div className="mb-6">
+          <h1 className={gradientText({ size: 'heading' })}>About</h1>
+          <p className="text-muted-foreground">{about.tagline}</p>
+        </div>
         <AboutContent about={about} />
       </Container>
     </PageTransitionWrapper>

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -24,16 +24,18 @@ export default function BlogsPage() {
   return (
     <PageTransitionWrapper>
       <Container>
-        <div className="flex flex-col items-center justify-center text-center space-y-6 py-16">
+        <div className="mb-6">
           <div className="flex items-center gap-3">
             <h1 className={gradientText({ size: 'heading' })}>{blogs.placeholderTitle}</h1>
             <span className="text-xs px-3 py-1 rounded-full border border-[var(--scheme-border)] text-[var(--scheme-accent)]">
               Coming soon
             </span>
           </div>
-          <p className="text-muted-foreground max-w-md">{blogs.placeholderDescription}</p>
+          <p className="text-muted-foreground">{blogs.placeholderDescription}</p>
+        </div>
+        <div className="space-y-3">
           <p className="text-sm text-muted-foreground">{blogs.comingSoonMessage}</p>
-          <Link href="/" className="text-sm text-[var(--scheme-accent)] hover:underline">
+          <Link href="/" className="inline-block text-sm text-[var(--scheme-accent)] hover:underline">
             {blogs.backLinkText}
           </Link>
         </div>

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -1,25 +1,41 @@
 import { Container } from "@/features/shared/container";
 import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
+import Link from "next/link";
 import type { Metadata } from "next";
-import { PageViewEvent } from "@/features/shared/analytics-event";
+import { blogs } from "../../../content/blogs";
 
 export const metadata: Metadata = {
-  title: "Blogs",
-  description: "My tech notes",
+  title: PAGE_META.blogs.title,
+  description: PAGE_META.blogs.description,
+  openGraph: {
+    title: PAGE_META.blogs.title,
+    description: PAGE_META.blogs.description,
+    url: `${SITE_URL}/blogs`,
+  },
+  twitter: {
+    title: PAGE_META.blogs.title,
+    description: PAGE_META.blogs.description,
+  },
 };
 
-export default function ContactPage() {
+export default function BlogsPage() {
   return (
     <PageTransitionWrapper>
-      <PageViewEvent page="blogs" />
       <Container>
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold mb-2">Blogs</h1>
-          <p className="text-muted-foreground">Start writing blogs.</p>
-        </div>
-
-        <div className="grid w-full grid-cols-1 gap-6 mx-auto sm:grid-cols-3">
-          Convert MD notes to Blogs WIP - MDX
+        <div className="flex flex-col items-center justify-center text-center space-y-6 py-16">
+          <div className="flex items-center gap-3">
+            <h1 className={gradientText({ size: 'heading' })}>{blogs.placeholderTitle}</h1>
+            <span className="text-xs px-3 py-1 rounded-full border border-[var(--scheme-border)] text-[var(--scheme-accent)]">
+              Coming soon
+            </span>
+          </div>
+          <p className="text-muted-foreground max-w-md">{blogs.placeholderDescription}</p>
+          <p className="text-sm text-muted-foreground">{blogs.comingSoonMessage}</p>
+          <Link href="/" className="text-sm text-[var(--scheme-accent)] hover:underline">
+            {blogs.backLinkText}
+          </Link>
         </div>
       </Container>
     </PageTransitionWrapper>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,13 +1,23 @@
 import { Container } from "@/features/shared/container";
 import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
 import { ContactCard } from "@/features/contact/contact-card";
-import { SOCIAL } from "@/lib/constants";
+import { SOCIAL, PAGE_META, SITE_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import { PageViewEvent } from "@/features/shared/analytics-event";
+import { gradientText } from "@/design/variants";
 
 export const metadata: Metadata = {
-  title: "Contact | Hammayo's Portfolio",
-  description: "Get in touch with me",
+  title: PAGE_META.contact.title,
+  description: PAGE_META.contact.description,
+  openGraph: {
+    title: PAGE_META.contact.title,
+    description: PAGE_META.contact.description,
+    url: `${SITE_URL}/contact`,
+  },
+  twitter: {
+    title: PAGE_META.contact.title,
+    description: PAGE_META.contact.description,
+  },
 };
 
 export default function ContactPage() {
@@ -16,7 +26,7 @@ export default function ContactPage() {
       <PageViewEvent page="contact" />
       <Container>
         <div className="mb-6">
-          <h1 className="text-3xl font-bold mb-2">Contact</h1>
+          <h1 className={gradientText({ size: 'heading' })}>Contact</h1>
           <p className="text-muted-foreground">Feel free to reach out through any of these platforms.</p>
         </div>
 
@@ -38,7 +48,6 @@ export default function ContactPage() {
             subtitle="GitHub"
             link={SOCIAL.github}
             linkText="View Profile"
-            variant="github"
           />
 
           {/* LinkedIn */}
@@ -55,7 +64,6 @@ export default function ContactPage() {
             subtitle="LinkedIn"
             link={SOCIAL.linkedin}
             linkText="View Profile"
-            variant="linkedin"
           />
 
           {/* Email */}
@@ -72,7 +80,6 @@ export default function ContactPage() {
             subtitle="Email"
             link={`mailto:${SOCIAL.email}`}
             linkText="Send Email"
-            variant="email"
           />
         </div>
       </Container>

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -23,14 +23,16 @@ export default function CVPage() {
   return (
     <PageTransitionWrapper>
       <Container>
-        <div className="flex flex-col items-center justify-center text-center space-y-6 py-16">
+        <div className="mb-6">
           <div className="flex items-center gap-3">
             <h1 className={gradientText({ size: 'heading' })}>CV</h1>
             <span className="text-xs px-3 py-1 rounded-full border border-[var(--scheme-border)] text-[var(--scheme-accent)]">
               Coming soon
             </span>
           </div>
-          <p className="text-muted-foreground max-w-md">{cv.placeholderText}</p>
+          <p className="text-muted-foreground">{cv.placeholderText}</p>
+        </div>
+        <div>
           <a
             href={cv.linkedIn}
             target="_blank"

--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -1,0 +1,46 @@
+import { Container } from "@/features/shared/container";
+import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
+import type { Metadata } from "next";
+import { cv } from "../../../content/cv";
+
+export const metadata: Metadata = {
+  title: PAGE_META.cv.title,
+  description: PAGE_META.cv.description,
+  openGraph: {
+    title: PAGE_META.cv.title,
+    description: PAGE_META.cv.description,
+    url: `${SITE_URL}/cv`,
+  },
+  twitter: {
+    title: PAGE_META.cv.title,
+    description: PAGE_META.cv.description,
+  },
+};
+
+export default function CVPage() {
+  return (
+    <PageTransitionWrapper>
+      <Container>
+        <div className="flex flex-col items-center justify-center text-center space-y-6 py-16">
+          <div className="flex items-center gap-3">
+            <h1 className={gradientText({ size: 'heading' })}>CV</h1>
+            <span className="text-xs px-3 py-1 rounded-full border border-[var(--scheme-border)] text-[var(--scheme-accent)]">
+              Coming soon
+            </span>
+          </div>
+          <p className="text-muted-foreground max-w-md">{cv.placeholderText}</p>
+          <a
+            href={cv.linkedIn}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-[var(--scheme-accent)] hover:underline"
+          >
+            View LinkedIn Profile →
+          </a>
+        </div>
+      </Container>
+    </PageTransitionWrapper>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,6 +139,11 @@
     background-clip: text;
   }
 
+  /* Darken gradient text in light mode — vivid scheme colours are too faint on white */
+  html:not(.dark) .gradient-text {
+    filter: brightness(0.65) saturate(1.3);
+  }
+
   .gradient-bg {
     background: linear-gradient(to right, var(--scheme-from), var(--scheme-via), var(--scheme-to));
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css';
 import type { Metadata, Viewport } from 'next';
-import { Inter, JetBrains_Mono } from 'next/font/google';
+import { JetBrains_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/providers/theme-provider';
 import { SchemeProvider } from '@/providers/scheme-provider';
 import { Header } from '@/features/shared/header';
@@ -14,15 +14,9 @@ import { Analytics } from '@/features/shared/analytics';
 import { StructuredData } from '@/features/shared/structured-data';
 import Script from 'next/script';
 
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap',
-});
-
 const jetbrainsMono = JetBrains_Mono({
   subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
+  variable: '--font-inter',
   display: 'swap',
 });
 
@@ -112,7 +106,7 @@ export default function RootLayout({
           `}
         </Script>
       </head>
-      <body className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased overflow-x-hidden`}>
+      <body className={`${jetbrainsMono.variable} font-sans antialiased overflow-x-hidden`}>
         <ThemeProvider
           attribute="class"
           defaultTheme={THEME.defaultTheme}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import { Header } from '@/features/shared/header';
 import { AnimatedBackgroundClient } from '@/features/shared/animated-background-client';
 import { basePath } from '@/lib/env';
 import { SITE, THEME, SITE_URL } from '@/lib/constants';
-import { RouteProgress } from '@/features/shared/route-progress';
 import { Footer } from '@/features/shared/footer';
 import { ErrorBoundary } from '@/features/shared/error-boundary';
 import { Analytics } from '@/features/shared/analytics';
@@ -118,7 +117,6 @@ export default function RootLayout({
               <div className="h-dvh bg-background text-foreground relative flex flex-col overflow-hidden">
                 <AnimatedBackgroundClient />
                 <Header />
-                <RouteProgress />
                 <main className="flex-1 flex flex-col overflow-y-auto pt-16 pb-4 relative z-[1]">
                   {children}
                 </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,51 +1,34 @@
 import { Container } from "@/features/shared/container";
 import { Hero } from "@/features/home/hero";
+import { HomepageBio } from "@/features/home/homepage-bio";
+import { SkillsStrip } from "@/features/home/skills-strip";
+import { CTARow } from "@/features/home/cta";
 import { PageTransitionWrapper } from "@/features/shared/page-transition-wrapper";
 import { PageViewEvent } from "@/features/shared/analytics-event";
-
-function generateStardate(): string {
-  const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = (now.getUTCMonth() + 1).toString().padStart(2, "0");
-  const day = now.getUTCDate().toString().padStart(2, "0");
-  return `${year}${month}.${day}`;
-}
+import { about } from "../../content/about";
+import { cv } from "../../content/cv";
 
 export default function HomePage() {
   return (
     <PageTransitionWrapper>
       <PageViewEvent page="home" />
       <div className="flex-1 flex flex-col items-center justify-center">
-        <Container className="text-center">
-          <div className="my-4 opacity-0 animate-fade-in animate-delay-500">
+        <Container className="text-center space-y-8">
+          <div className="opacity-0 animate-fade-in animate-delay-500">
             <Hero />
           </div>
           <div className="opacity-0 animate-fade-in animate-delay-200">
-            <div className="text-sm md:text-base text-muted-foreground leading-relaxed tracking-tight space-y-3">
-              <p>
-                Captain's log, stardate {generateStardate()}: For last 20 years,
-                I've boldly navigated the digital frontier, charting solutions
-                across uncharted sectors—finance's nebulae, justice's asteroid
-                belts, and the bureaucratic wormholes of public service.
-              </p>
-
-              <p>
-                Armed with a tricorder of Microsoft tech and a starship
-                engineered from micro-services and Docker containers at warp
-                speed, I've allied with Starfleet's HMPPS to dismantle legacy
-                system Borgs and assimilate innovation. My crew? A
-                cross-functional away team, trained in the Vulcan discipline of
-                clean code and the Klingon art of relentless problem-solving.
-              </p>
-
-              <p>
-                Mission priority: To seek out new patterns, elevate
-                civilizations with scalable tech, and ensure no enterprise is
-                left stranded in the alpha quadrant of obsolescence. Engage at
-                will — let's pioneer the final frontier of software, where no
-                challenge has gone before. 🖖
-              </p>
-            </div>
+            <HomepageBio
+              template={about.homepageBioTemplate}
+              extra={about.homepageBioExtra}
+              careerStartYear={about.careerStartYear}
+            />
+          </div>
+          <div className="opacity-0 animate-fade-in animate-delay-300">
+            <SkillsStrip skills={cv.skills} />
+          </div>
+          <div className="opacity-0 animate-fade-in animate-delay-400">
+            <CTARow />
           </div>
         </Container>
       </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -4,10 +4,21 @@ import { ProjectCard } from "@/features/projects/project-card";
 import { fetchGitHubData } from "@/lib/github";
 import type { Metadata } from "next";
 import { PageViewEvent } from "@/features/shared/analytics-event";
+import { PAGE_META, SITE_URL } from "@/lib/constants";
+import { gradientText } from "@/design/variants";
 
 export const metadata: Metadata = {
-  title: "Projects | Hammayo's Portfolio",
-  description: "Explore my latest projects and open source contributions on GitHub.",
+  title: PAGE_META.projects.title,
+  description: PAGE_META.projects.description,
+  openGraph: {
+    title: PAGE_META.projects.title,
+    description: PAGE_META.projects.description,
+    url: `${SITE_URL}/projects`,
+  },
+  twitter: {
+    title: PAGE_META.projects.title,
+    description: PAGE_META.projects.description,
+  },
 };
 
 // This ensures the page revalidates every 1 hour
@@ -34,7 +45,7 @@ export default async function ProjectsPage() {
       <PageViewEvent page="projects" />
       <Container>
         <div className="mb-6">
-          <h1 className="text-3xl font-bold mb-2">Projects</h1>
+          <h1 className={gradientText({ size: 'heading' })}>Projects</h1>
           <p className="text-muted-foreground">Explore my most recent projects and open source contributions.</p>
         </div>
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,30 +1,47 @@
 import { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/constants';
 
 export const dynamic = 'force-static';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://hammayo.github.io';
   const lastModified = new Date();
 
   return [
     {
-      url: baseUrl,
+      url: SITE_URL,
       lastModified,
       changeFrequency: 'monthly',
       priority: 1,
     },
     {
-      url: `${baseUrl}/projects`,
+      url: `${SITE_URL}/about`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/projects`,
       lastModified,
       changeFrequency: 'weekly',
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/contact`,
+      url: `${SITE_URL}/blogs`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/cv`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/contact`,
       lastModified,
       changeFrequency: 'monthly',
       priority: 0.5,
     },
   ];
 }
-

--- a/src/design/variants.ts
+++ b/src/design/variants.ts
@@ -66,8 +66,8 @@ export const ctaButton = cva(
   {
     variants: {
       variant: {
-        gradient: 'gradient-bg text-white font-semibold shadow-lg ring-1 ring-white/20 hover:opacity-90 focus-visible:ring-[var(--scheme-from)]',
-        ghost:    'border-2 border-foreground/30 text-foreground font-semibold hover:border-foreground/60 hover:bg-foreground/10 focus-visible:ring-border',
+        gradient: 'bg-gradient-to-r from-violet-600 via-purple-600 to-indigo-600 text-white font-semibold shadow-lg hover:from-violet-500 hover:via-purple-500 hover:to-indigo-500 hover:shadow-violet-500/40 hover:scale-[1.03] active:scale-[0.97] focus-visible:ring-violet-500',
+        ghost:    'border-2 border-foreground/40 text-foreground font-semibold hover:border-violet-400 hover:text-violet-400 hover:bg-violet-500/10 hover:scale-[1.03] active:scale-[0.97] focus-visible:ring-border',
       },
     },
     defaultVariants: {

--- a/src/design/variants.ts
+++ b/src/design/variants.ts
@@ -55,3 +55,23 @@ export const accentTag = cva(
     },
   }
 );
+
+/**
+ * CTA button variant.
+ * Primary uses the scheme gradient background.
+ * Ghost uses a transparent background with border.
+ */
+export const ctaButton = cva(
+  'inline-flex items-center justify-center rounded-lg px-6 py-3 text-sm font-medium transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        gradient: 'gradient-bg text-white shadow-sm hover:opacity-90 focus-visible:ring-[var(--scheme-from)]',
+        ghost:    'border border-border text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:ring-border',
+      },
+    },
+    defaultVariants: {
+      variant: 'gradient',
+    },
+  }
+);

--- a/src/design/variants.ts
+++ b/src/design/variants.ts
@@ -66,8 +66,8 @@ export const ctaButton = cva(
   {
     variants: {
       variant: {
-        gradient: 'gradient-bg text-white shadow-sm hover:opacity-90 focus-visible:ring-[var(--scheme-from)]',
-        ghost:    'border border-border text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:ring-border',
+        gradient: 'gradient-bg text-white font-semibold shadow-lg ring-1 ring-white/20 hover:opacity-90 focus-visible:ring-[var(--scheme-from)]',
+        ghost:    'border-2 border-foreground/30 text-foreground font-semibold hover:border-foreground/60 hover:bg-foreground/10 focus-visible:ring-border',
       },
     },
     defaultVariants: {

--- a/src/features/about/about-content.tsx
+++ b/src/features/about/about-content.tsx
@@ -1,0 +1,68 @@
+import Image from 'next/image';
+import { gradientText, accentTag } from '@/design/variants';
+import { basePath } from '@/lib/env';
+import imageLoader from '@/lib/imageLoader';
+import type { about as AboutType } from '../../../content/about';
+
+interface AboutContentProps {
+  about: typeof AboutType;
+}
+
+export function AboutContent({ about }: AboutContentProps) {
+  const avatarSrc = `${basePath}${about.avatarPath}`;
+  const fallbackSrc = `${basePath}/_hb-logo.png`;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      {/* Hero row: avatar + name + tagline */}
+      <div className="flex items-start gap-5">
+        <div className="relative flex-shrink-0">
+          <Image
+            loader={imageLoader}
+            src={avatarSrc}
+            alt={about.name}
+            width={80}
+            height={80}
+            className="rounded-full ring-2 ring-[var(--scheme-border)] scheme-glow"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).src = fallbackSrc;
+            }}
+            unoptimized
+          />
+        </div>
+        <div>
+          <h1 className={gradientText({ size: 'heading' })}>
+            <span className="hidden md:inline animate-gradient"
+              style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
+            >{about.name}</span>
+            <span className="md:hidden animate-gradient"
+              style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
+            >{about.shortName}</span>
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">{about.tagline}</p>
+        </div>
+      </div>
+
+      {/* Bio */}
+      <p className="text-sm md:text-base text-muted-foreground leading-relaxed">{about.bio}</p>
+
+      {/* Sectors */}
+      <div className="space-y-2">
+        <h2 className="text-xs uppercase tracking-widest text-muted-foreground">Sectors & Domains</h2>
+        <div className="flex flex-wrap gap-2">
+          {about.sectors.map((sector) => (
+            <span key={sector} className={accentTag()}>
+              {sector}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Philosophy */}
+      <div className="border-l-2 border-[var(--scheme-border)] pl-4">
+        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-1">Philosophy</p>
+        <p className="text-sm md:text-base italic text-foreground/80">&ldquo;{about.philosophy}&rdquo;</p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/about/about-content.tsx
+++ b/src/features/about/about-content.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { gradientText, accentTag } from '@/design/variants';
-import { basePath } from '@/lib/env';
+import { accentTag } from '@/design/variants';
 import imageLoader from '@/lib/imageLoader';
 import type { about as AboutType } from '../../../content/about';
 
@@ -11,21 +10,20 @@ interface AboutContentProps {
 }
 
 export function AboutContent({ about }: AboutContentProps) {
-  const avatarSrc = `${basePath}${about.avatarPath}`;
-  const fallbackSrc = `${basePath}/_hb-logo.png`;
+  const fallbackSrc = '/_hb-logo.png';
 
   return (
     <div className="max-w-2xl mx-auto space-y-8">
-      {/* Hero row: avatar + name + tagline */}
-      <div className="flex items-start gap-5">
+      {/* Avatar + name row */}
+      <div className="flex items-center gap-5">
         <div className="relative flex-shrink-0">
           <Image
             loader={imageLoader}
-            src={avatarSrc}
+            src={about.avatarPath}
             alt={about.name}
             width={80}
             height={80}
-            className="rounded-full ring-2 ring-[var(--scheme-border)] scheme-glow"
+            className="rounded-full ring-2 ring-[var(--scheme-border)]"
             onError={(e) => {
               (e.currentTarget as HTMLImageElement).src = fallbackSrc;
             }}
@@ -33,15 +31,16 @@ export function AboutContent({ about }: AboutContentProps) {
           />
         </div>
         <div>
-          <h1 className={gradientText({ size: 'heading' })}>
-            <span className="hidden md:inline animate-gradient"
+          <p className="text-lg font-semibold">
+            <span
+              className="hidden md:inline animate-gradient text-transparent bg-clip-text"
               style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
             >{about.name}</span>
-            <span className="md:hidden animate-gradient"
+            <span
+              className="md:hidden animate-gradient text-transparent bg-clip-text"
               style={{ backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)', backgroundSize: '400%' }}
             >{about.shortName}</span>
-          </h1>
-          <p className="text-muted-foreground text-sm mt-1">{about.tagline}</p>
+          </p>
         </div>
       </div>
 

--- a/src/features/about/about-content.tsx
+++ b/src/features/about/about-content.tsx
@@ -4,13 +4,14 @@ import Image from 'next/image';
 import { accentTag } from '@/design/variants';
 import imageLoader from '@/lib/imageLoader';
 import type { about as AboutType } from '../../../content/about';
+import {basePath} from "@/lib/env";
 
 interface AboutContentProps {
   about: typeof AboutType;
 }
 
 export function AboutContent({ about }: AboutContentProps) {
-  const fallbackSrc = '/_hb-logo.png';
+  const fallbackSrc = `${basePath}/images/_hb-logo.png`;
 
   return (
     <div className="max-w-2xl mx-auto space-y-8">

--- a/src/features/about/about-content.tsx
+++ b/src/features/about/about-content.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import { gradientText, accentTag } from '@/design/variants';
 import { basePath } from '@/lib/env';

--- a/src/features/contact/contact-card.tsx
+++ b/src/features/contact/contact-card.tsx
@@ -4,50 +4,24 @@ import { type ReactNode } from "react";
 import { CardEffects, cardBaseClasses } from "@/features/shared/ui/card-effects";
 
 interface ContactCardProps {
-  icon: ReactNode;
-  title: string;
+  icon:     ReactNode;
+  title:    string;
   subtitle: string;
-  link: string;
+  link:     string;
   linkText: string;
-  variant: "github" | "linkedin" | "email";
 }
 
-export function ContactCard({
-  icon,
-  title,
-  subtitle,
-  link,
-  linkText,
-  variant,
-}: ContactCardProps) {
-  const variants = {
-    github: {
-      icon: "dark:border-purple-500/30 border-purple-300/30 group-hover:border-purple-500/50",
-      title: "bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500",
-      button: "bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500 hover:from-purple-600 hover:via-cyan-600 hover:to-green-600",
-    },
-    linkedin: {
-      icon: "dark:border-blue-500/30 border-blue-300/30 group-hover:border-blue-500/50",
-      title: "bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500",
-      button: "bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 hover:from-blue-600 hover:via-indigo-600 hover:to-purple-600",
-    },
-    email: {
-      icon: "dark:border-cyan-500/30 border-cyan-300/30 group-hover:border-cyan-500/50",
-      title: "bg-gradient-to-r from-cyan-500 via-blue-500 to-teal-500",
-      button: "bg-gradient-to-r from-cyan-500 via-blue-500 to-teal-500 hover:from-cyan-600 hover:via-blue-600 hover:to-teal-600",
-    },
-  };
-
-  const currentVariant = variants[variant];
+export function ContactCard({ icon, title, subtitle, link, linkText }: ContactCardProps) {
+  const isExternal = !link.startsWith("mailto:");
 
   return (
     <CardEffects>
       <div className="flex flex-col items-center gap-4 p-8">
-        <div className={`w-16 h-16 flex items-center justify-center border rounded-full dark:bg-black/30 bg-white/30 backdrop-blur-md transition-all duration-300 ${currentVariant.icon}`}>
+        <div className="w-16 h-16 flex items-center justify-center border rounded-full dark:bg-black/30 bg-white/30 backdrop-blur-md transition-all duration-300 scheme-border group-hover:scheme-glow">
           {icon}
         </div>
         <div className="flex flex-col items-center mt-2">
-          <h3 className={`text-xl font-medium tracking-tight text-transparent bg-clip-text transition-all duration-300 opacity-80 group-hover:opacity-100 ${currentVariant.title}`}>
+          <h3 className="gradient-text text-xl font-medium tracking-tight transition-all duration-300 opacity-80 group-hover:opacity-100">
             {title}
           </h3>
           <span className={`mt-4 text-sm text-center ${cardBaseClasses.description}`}>
@@ -56,9 +30,9 @@ export function ContactCard({
         </div>
         <a
           href={link}
-          target={link.startsWith("mailto:") ? undefined : "_blank"}
-          rel={link.startsWith("mailto:") ? undefined : "noopener noreferrer"}
-          className={`${cardBaseClasses.button} mt-6 text-white ${currentVariant.button}`}
+          target={isExternal ? "_blank" : undefined}
+          rel={isExternal ? "noopener noreferrer" : undefined}
+          className={`${cardBaseClasses.button} gradient-bg mt-6 text-white`}
         >
           {linkText}
         </a>

--- a/src/features/contact/contact-card.tsx
+++ b/src/features/contact/contact-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { type ReactNode } from "react";
-import { CardEffects, cardBaseClasses } from "@/features/shared/ui/card-effects";
+import { CardEffects } from "@/features/shared/ui/card-effects";
+import { ctaButton } from "@/design/variants";
 
 interface ContactCardProps {
   icon:     ReactNode;
@@ -24,7 +25,7 @@ export function ContactCard({ icon, title, subtitle, link, linkText }: ContactCa
           <h3 className="gradient-text text-xl font-medium tracking-tight transition-all duration-300 opacity-80 group-hover:opacity-100">
             {title}
           </h3>
-          <span className={`mt-4 text-sm text-center ${cardBaseClasses.description}`}>
+          <span className="mt-4 text-sm text-center text-zinc-600 dark:text-zinc-400 group-hover:text-purple-900/90 dark:group-hover:text-zinc-300 transition-colors">
             {subtitle}
           </span>
         </div>
@@ -32,7 +33,7 @@ export function ContactCard({ icon, title, subtitle, link, linkText }: ContactCa
           href={link}
           target={isExternal ? "_blank" : undefined}
           rel={isExternal ? "noopener noreferrer" : undefined}
-          className={`${cardBaseClasses.button} gradient-bg mt-6 text-white`}
+          className={`${ctaButton({ variant: 'gradient' })} mt-6`}
         >
           {linkText}
         </a>

--- a/src/features/home/cta.tsx
+++ b/src/features/home/cta.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { ctaButton } from '@/design/variants';
+
+export function CTARow() {
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+      <Link href="/projects" className={ctaButton({ variant: 'gradient' })}>
+        View Projects
+      </Link>
+      <Link href="/contact" className={ctaButton({ variant: 'ghost' })}>
+        Get in Touch
+      </Link>
+    </div>
+  );
+}

--- a/src/features/home/homepage-bio.tsx
+++ b/src/features/home/homepage-bio.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface HomepageBioProps {
+  template:        string;
+  extra:           string[];
+  careerStartYear: number;
+}
+
+function formatStardate(d: Date): string {
+  const year  = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day   = String(d.getDate()).padStart(2, '0');
+  return `${year}${month}.${day}`;
+}
+
+function interpolate(template: string, values: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) =>
+    key in values ? String(values[key]) : `{${key}}`
+  );
+}
+
+export function HomepageBio({ template, extra, careerStartYear }: HomepageBioProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const stardate = mounted ? formatStardate(new Date()) : '......';
+  const years    = mounted ? new Date().getFullYear() - careerStartYear : '..';
+
+  const firstPara = interpolate(template, { stardate, years });
+
+  return (
+    <div className="text-sm md:text-base text-muted-foreground leading-relaxed tracking-tight space-y-3">
+      <p>{firstPara}</p>
+      {extra.map((para, i) => (
+        <p key={i}>{para}</p>
+      ))}
+    </div>
+  );
+}

--- a/src/features/home/skills-strip.tsx
+++ b/src/features/home/skills-strip.tsx
@@ -1,0 +1,25 @@
+import { accentTag } from '@/design/variants';
+
+interface SkillsStripProps {
+  skills: {
+    languages: string[];
+    platforms: string[];
+    tools:     string[];
+  };
+}
+
+export function SkillsStrip({ skills }: SkillsStripProps) {
+  const all = [...skills.languages, ...skills.platforms, ...skills.tools];
+
+  if (all.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 justify-center">
+      {all.map((skill) => (
+        <span key={skill} className={accentTag()}>
+          {skill}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/features/projects/project-card.tsx
+++ b/src/features/projects/project-card.tsx
@@ -3,6 +3,10 @@
 import { CardContent } from "@/features/shared/ui/card";
 import type { GitHubRepository } from "@/lib/github";
 import { Star, GitFork, ExternalLink } from "lucide-react";
+import { CardEffects, cardBaseClasses } from "@/features/shared/ui/card-effects";
+import { Button } from "@/features/shared/ui/button";
+import { accentTag } from "@/design/variants";
+import { format } from "date-fns";
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -11,9 +15,6 @@ function GithubIcon({ className }: { className?: string }) {
     </svg>
   );
 }
-import { CardEffects, cardBaseClasses } from "@/features/shared/ui/card-effects";
-import { Button } from "@/features/shared/ui/button";
-import { format } from "date-fns";
 
 interface ProjectCardProps {
   repo: GitHubRepository;
@@ -23,7 +24,7 @@ interface ProjectCardProps {
 
 export function ProjectCard({ repo, index, featured = false }: ProjectCardProps) {
   return (
-    <CardEffects 
+    <CardEffects
       variant={featured ? "featured" : "default"}
       className={`animate-in fade-in-50 duration-500 delay-${index * 100}`}
     >
@@ -57,14 +58,11 @@ export function ProjectCard({ repo, index, featured = false }: ProjectCardProps)
           {/* Description */}
           <p className="text-sm text-muted-foreground mb-4">{repo.description}</p>
 
-          {/* Topics */}
+          {/* Topics — scheme-aware accent tags */}
           {repo.topics.length > 0 && (
             <div className="flex flex-wrap gap-2 mb-4">
               {repo.topics.map((topic) => (
-                <span
-                  key={topic}
-                  className="px-2 py-1 text-xs rounded-full bg-primary/10 text-primary"
-                >
+                <span key={topic} className={accentTag()}>
                   {topic}
                 </span>
               ))}
@@ -75,9 +73,7 @@ export function ProjectCard({ repo, index, featured = false }: ProjectCardProps)
           <div className="mt-auto flex items-center justify-between">
             <div className="flex items-center gap-2">
               {repo.language && (
-                <span className="text-sm text-muted-foreground">
-                  {repo.language}
-                </span>
+                <span className="text-sm text-muted-foreground">{repo.language}</span>
               )}
               <span className="text-sm text-muted-foreground">
                 Updated {format(new Date(repo.updated_at), 'MMM d, yyyy')}
@@ -85,14 +81,14 @@ export function ProjectCard({ repo, index, featured = false }: ProjectCardProps)
             </div>
             <div className="flex gap-2">
               <Button variant="ghost" size="sm" asChild>
-                <a href={repo.html_url} target="_blank" rel="noreferrer">
+                <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
                   <GithubIcon className="w-4 h-4 mr-1" />
                   Code
                 </a>
               </Button>
               {repo.homepage && (
                 <Button variant="ghost" size="sm" asChild>
-                  <a href={repo.homepage} target="_blank" rel="noreferrer">
+                  <a href={repo.homepage} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="w-4 h-4 mr-1" />
                     Demo
                   </a>

--- a/src/features/shared/copyright-year.tsx
+++ b/src/features/shared/copyright-year.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface CopyrightYearProps {
+  launchYear: number;
+}
+
+export function CopyrightYear({ launchYear }: CopyrightYearProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const current = new Date().getFullYear();
+
+  if (!mounted) {
+    return <span>{launchYear}</span>;
+  }
+
+  return (
+    <span>{launchYear === current ? current : `${launchYear}–${current}`}</span>
+  );
+}

--- a/src/features/shared/footer.tsx
+++ b/src/features/shared/footer.tsx
@@ -23,7 +23,7 @@ function LinkedinIcon({ className }: { className?: string }) {
 export function Footer({ className }: { className?: string }) {
   return (
     <footer className={`w-full border-t border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60${className ? ` ${className}` : ''}`}>
-      <div className="container flex items-center justify-between gap-4 py-2">
+      <div className="container px-4 mx-auto max-w-7xl flex items-center justify-between gap-4 py-2">
         <div className="flex items-center">
           <p className="text-xs text-muted-foreground">
             Built by{' '}

--- a/src/features/shared/footer.tsx
+++ b/src/features/shared/footer.tsx
@@ -1,7 +1,8 @@
-import { SITE, SOCIAL } from "@/lib/constants";
+import { SITE, SOCIAL, SITE_LAUNCH_YEAR } from "@/lib/constants";
 import { Button } from "@/features/shared/ui/button";
 import { Mail } from "lucide-react";
 import { ThemeToggle } from "./theme-toggle";
+import { CopyrightYear } from "./copyright-year";
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -25,27 +26,27 @@ export function Footer({ className }: { className?: string }) {
       <div className="container flex items-center justify-between gap-4 py-2">
         <div className="flex items-center">
           <p className="text-xs text-muted-foreground">
-            Built by {" "}
+            Built by{' '}
             <a
-              href={SOCIAL.github + "?"}
+              href={SOCIAL.github}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="font-medium underline underline-offset-4"
             >
               {SITE.author}
-            </a> 
-            &nbsp;&copy; {new Date().getUTCFullYear()}
+            </a>
+            {' '}&copy; <CopyrightYear launchYear={SITE_LAUNCH_YEAR} />
           </p>
         </div>
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="icon" asChild>
-            <a href={SOCIAL.github} target="_blank" rel="noreferrer">
+            <a href={SOCIAL.github} target="_blank" rel="noopener noreferrer">
               <GithubIcon className="h-4 w-4" />
               <span className="sr-only">GitHub</span>
             </a>
           </Button>
           <Button variant="ghost" size="icon" asChild>
-            <a href={SOCIAL.linkedin} target="_blank" rel="noreferrer">
+            <a href={SOCIAL.linkedin} target="_blank" rel="noopener noreferrer">
               <LinkedinIcon className="h-4 w-4" />
               <span className="sr-only">LinkedIn</span>
             </a>
@@ -61,6 +62,6 @@ export function Footer({ className }: { className?: string }) {
           </div>
         </div>
       </div>
-    </footer>    
+    </footer>
   );
 }

--- a/src/features/shared/header.tsx
+++ b/src/features/shared/header.tsx
@@ -3,19 +3,60 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { Menu } from "lucide-react";
 import { Container } from "./container";
+import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
 import { cn } from "@/lib/utils";
 import { basePath } from "@/lib/env";
 
+const NAV_LINKS = [
+  { href: "/about",    label: "About"    },
+  { href: "/projects", label: "Projects" },
+  { href: "/blogs",    label: "Blogs"    },
+  { href: "/contact",  label: "Contact"  },
+] as const;
+
+const gradientClasses =
+  "text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500 font-medium";
+const inactiveClasses =
+  "dark:text-zinc-400 text-zinc-600 hover:text-transparent hover:bg-clip-text hover:bg-gradient-to-r hover:from-purple-500 hover:via-cyan-500 hover:to-green-500";
+
+function NavLink({ href, label, pathname, onClick }: {
+  href: string;
+  label: string;
+  pathname: string;
+  onClick?: () => void;
+}) {
+  return (
+    <Link
+      href={href}
+      prefetch
+      onClick={onClick}
+      className={cn(
+        "duration-300 transition-all tracking-tight",
+        pathname === href ? gradientClasses : inactiveClasses
+      )}
+    >
+      {label}
+    </Link>
+  );
+}
+
 export function Header() {
-  const pathname = usePathname();
-  const logoPath = `${basePath}/images/_hb-logo.png`;
+  const pathname  = usePathname();
+  const logoPath  = `${basePath}/images/_hb-logo.png`;
+  const [open, setOpen] = useState(false);
 
   return (
-    <header role="banner" className="fixed top-0 left-0 right-0 z-50 dark:bg-zinc-950/80 bg-white/80 backdrop-blur-xl border-b dark:border-zinc-800/50 border-zinc-200/50">
+    <header
+      role="banner"
+      className="fixed top-0 left-0 right-0 z-50 dark:bg-zinc-950/80 bg-white/80 backdrop-blur-xl border-b dark:border-zinc-800/50 border-zinc-200/50"
+    >
       <Container>
         <nav role="navigation" aria-label="Main navigation">
           <div className="flex items-center justify-between py-2">
+            {/* Logo */}
             <Link
               href="/"
               prefetch
@@ -40,31 +81,38 @@ export function Header() {
               >Hammy</span>
             </Link>
 
-            <div className="flex items-center gap-8">
-              <Link
-                href="/projects"
-                prefetch
-                className={cn(
-                  "duration-300 transition-all tracking-tight",
-                  pathname === "/projects"
-                    ? "text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500 font-medium"
-                    : "dark:text-zinc-400 text-zinc-600 hover:text-transparent hover:bg-clip-text hover:bg-gradient-to-r hover:from-purple-500 hover:via-cyan-500 hover:to-green-500"
-                )}
-              >
-                Projects
-              </Link>
-              <Link
-                href="/contact"
-                prefetch
-                className={cn(
-                  "duration-300 transition-all tracking-tight",
-                  pathname === "/contact"
-                    ? "text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500 font-medium"
-                    : "dark:text-zinc-400 text-zinc-600 hover:text-transparent hover:bg-clip-text hover:bg-gradient-to-r hover:from-purple-500 hover:via-cyan-500 hover:to-green-500"
-                )}
-              >
-                Contact
-              </Link>
+            {/* Desktop nav */}
+            <div className="hidden md:flex items-center gap-8">
+              {NAV_LINKS.map(({ href, label }) => (
+                <NavLink key={href} href={href} label={label} pathname={pathname} />
+              ))}
+            </div>
+
+            {/* Mobile hamburger */}
+            <div className="md:hidden">
+              <Sheet open={open} onOpenChange={setOpen}>
+                <SheetTrigger asChild>
+                  <button
+                    aria-label="Open navigation"
+                    className="p-2 rounded-md dark:text-zinc-400 text-zinc-600 hover:text-foreground transition-colors"
+                  >
+                    <Menu className="h-5 w-5" />
+                  </button>
+                </SheetTrigger>
+                <SheetContent side="right" className="w-64 pt-12">
+                  <nav aria-label="Mobile navigation" className="flex flex-col gap-6 mt-4">
+                    {NAV_LINKS.map(({ href, label }) => (
+                      <NavLink
+                        key={href}
+                        href={href}
+                        label={label}
+                        pathname={pathname}
+                        onClick={() => setOpen(false)}
+                      />
+                    ))}
+                  </nav>
+                </SheetContent>
+              </Sheet>
             </div>
           </div>
         </nav>

--- a/src/features/shared/header.tsx
+++ b/src/features/shared/header.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { Menu } from "lucide-react";
 import { Container } from "./container";
-import { Sheet, SheetContent, SheetTrigger } from "./ui/sheet";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "./ui/sheet";
 import { cn } from "@/lib/utils";
 import { basePath } from "@/lib/env";
 
@@ -110,6 +110,7 @@ export function Header() {
                   </button>
                 </SheetTrigger>
                 <SheetContent side="right" className="w-64 pt-12">
+                  <SheetTitle className="sr-only">Navigation</SheetTitle>
                   <nav aria-label="Mobile navigation" className="flex flex-col gap-6 mt-4">
                     {NAV_LINKS.map(({ href, label }) => (
                       <NavLink

--- a/src/features/shared/header.tsx
+++ b/src/features/shared/header.tsx
@@ -17,26 +17,38 @@ const NAV_LINKS = [
   { href: "/contact",  label: "Contact"  },
 ] as const;
 
-const activeClasses  = "gradient-text text-transparent font-semibold";
-const inactiveClasses = "text-foreground/60 hover:text-foreground transition-colors";
-
 function NavLink({ href, label, pathname, onClick }: {
   href: string;
   label: string;
   pathname: string;
   onClick?: () => void;
 }) {
+  // Strip trailing slash before comparing (Next.js can return either form)
+  const isActive = pathname.replace(/\/$/, '') === href;
+
   return (
     <Link
       href={href}
       prefetch
       onClick={onClick}
       className={cn(
-        "duration-300 transition-all tracking-tight",
-        pathname === href ? activeClasses : inactiveClasses
+        "tracking-tight transition-all duration-300 font-medium",
+        isActive
+          ? "font-semibold"
+          : "text-muted-foreground hover:text-foreground"
       )}
     >
-      {label}
+      {isActive ? (
+        <span
+          className="text-transparent bg-clip-text"
+          style={{
+            backgroundImage: 'linear-gradient(to right, #a855f7, #818cf8, #38bdf8, #34d399, #f472b6, #a855f7)',
+            backgroundSize: '300%',
+          }}
+        >
+          {label}
+        </span>
+      ) : label}
     </Link>
   );
 }
@@ -49,7 +61,7 @@ export function Header() {
   return (
     <header
       role="banner"
-      className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-xl border-b border-border/50"
+      className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md border-b border-border/50"
     >
       <Container>
         <nav role="navigation" aria-label="Main navigation">

--- a/src/features/shared/header.tsx
+++ b/src/features/shared/header.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { Menu } from "lucide-react";
 import { Container } from "./container";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "./ui/sheet";
+import { RouteProgress } from "./route-progress";
 import { cn } from "@/lib/utils";
 import { basePath } from "@/lib/env";
 
@@ -61,7 +62,7 @@ export function Header() {
   return (
     <header
       role="banner"
-      className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md border-b border-border/50"
+      className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md border-b border-border/50 overflow-hidden"
     >
       <Container>
         <nav role="navigation" aria-label="Main navigation">
@@ -128,6 +129,7 @@ export function Header() {
           </div>
         </nav>
       </Container>
+      <RouteProgress />
     </header>
   );
 }

--- a/src/features/shared/header.tsx
+++ b/src/features/shared/header.tsx
@@ -17,10 +17,8 @@ const NAV_LINKS = [
   { href: "/contact",  label: "Contact"  },
 ] as const;
 
-const gradientClasses =
-  "text-transparent bg-clip-text bg-gradient-to-r from-purple-500 via-cyan-500 to-green-500 font-medium";
-const inactiveClasses =
-  "dark:text-zinc-400 text-zinc-600 hover:text-transparent hover:bg-clip-text hover:bg-gradient-to-r hover:from-purple-500 hover:via-cyan-500 hover:to-green-500";
+const activeClasses  = "gradient-text text-transparent font-semibold";
+const inactiveClasses = "text-foreground/60 hover:text-foreground transition-colors";
 
 function NavLink({ href, label, pathname, onClick }: {
   href: string;
@@ -35,7 +33,7 @@ function NavLink({ href, label, pathname, onClick }: {
       onClick={onClick}
       className={cn(
         "duration-300 transition-all tracking-tight",
-        pathname === href ? gradientClasses : inactiveClasses
+        pathname === href ? activeClasses : inactiveClasses
       )}
     >
       {label}
@@ -51,7 +49,7 @@ export function Header() {
   return (
     <header
       role="banner"
-      className="fixed top-0 left-0 right-0 z-50 dark:bg-zinc-950/80 bg-white/80 backdrop-blur-xl border-b dark:border-zinc-800/50 border-zinc-200/50"
+      className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-xl border-b border-border/50"
     >
       <Container>
         <nav role="navigation" aria-label="Main navigation">

--- a/src/features/shared/loading.tsx
+++ b/src/features/shared/loading.tsx
@@ -1,9 +1,0 @@
-import { Loader } from "lucide-react";
-
-export function Loading() {
-  return (
-    <div className="flex items-center justify-center min-h-[200px]">
-      <Loader className="h-8 w-8 animate-spin text-primary/60" />
-    </div>
-  );
-}

--- a/src/features/shared/page-transition-wrapper.tsx
+++ b/src/features/shared/page-transition-wrapper.tsx
@@ -15,13 +15,9 @@ export function PageTransitionWrapper({ children }: PageTransitionWrapperProps) 
     <motion.div
       key={pathname}
       className="flex-1 flex flex-col"
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -8 }}
-      transition={{
-        duration: 0.2,
-        ease: "easeOut"
-      }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.15, ease: "easeOut" }}
     >
       {children}
     </motion.div>

--- a/src/features/shared/route-progress.tsx
+++ b/src/features/shared/route-progress.tsx
@@ -19,7 +19,7 @@ const ProgressIndicator = () => {
 
   return (
     <Progress.Root
-      className="fixed top-[45px] left-0 right-0 z-[200] h-[2px] w-full overflow-hidden bg-transparent"
+      className="absolute bottom-0 left-0 right-0 z-[200] h-[2px] w-full overflow-hidden bg-transparent"
       style={{
         opacity: visible ? 1 : 0,
         transition: "opacity 400ms ease-in-out"

--- a/src/features/shared/route-progress.tsx
+++ b/src/features/shared/route-progress.tsx
@@ -1,20 +1,44 @@
 "use client";
 
-import { useEffect, useState, Suspense, memo } from "react";
+import { useEffect, useState, Suspense, memo, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import * as Progress from "@radix-ui/react-progress";
 
-// Create a separate client component that uses useSearchParams
 const ProgressIndicator = () => {
   const [progress, setProgress] = useState(0);
   const [visible, setVisible] = useState(false);
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   useEffect(() => {
+    // Clear any in-flight timers from a previous navigation
+    timers.current.forEach(clearTimeout);
+    timers.current = [];
+
+    // Reset to 0 and show bar
     setProgress(0);
-    setProgress(100);    
     setVisible(true);
+
+    // Double rAF ensures the browser paints the 0% state before we
+    // animate to 100%, giving the CSS transition something to run
+    const raf1 = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        setProgress(100);
+
+        // Fade out after the fill animation completes (400ms) + small buffer
+        const hide = setTimeout(() => {
+          setVisible(false);
+          timers.current = [];
+        }, 600);
+        timers.current.push(hide);
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf1);
+      timers.current.forEach(clearTimeout);
+    };
   }, [pathname, searchParams]);
 
   return (
@@ -22,22 +46,21 @@ const ProgressIndicator = () => {
       className="absolute bottom-0 left-0 right-0 z-[200] h-[2px] w-full overflow-hidden bg-transparent"
       style={{
         opacity: visible ? 1 : 0,
-        transition: "opacity 400ms ease-in-out"
+        transition: "opacity 300ms ease-in-out",
       }}
       value={progress}
     >
       <Progress.Indicator
-        className="h-full w-full bg-gradient-to-l from-purple-500 via-cyan-500 to-green-500"
+        className="h-full w-full bg-gradient-to-r from-violet-500 via-cyan-400 to-green-400"
         style={{
           transform: `translateX(-${100 - progress}%)`,
-          transition: "transform 400ms cubic-bezier(0.4, 0, 0.2, 1)"
+          transition: "transform 400ms cubic-bezier(0.4, 0, 0.2, 1)",
         }}
       />
     </Progress.Root>
   );
 };
 
-// Main component wrapped with Suspense
 export const RouteProgress = memo(function RouteProgress() {
   return (
     <Suspense fallback={null}>

--- a/src/features/shared/theme-toggle.tsx
+++ b/src/features/shared/theme-toggle.tsx
@@ -23,7 +23,7 @@ export function ThemeToggle() {
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" side="top">
         <DropdownMenuItem onClick={() => setTheme("light")}>
           Light
         </DropdownMenuItem>

--- a/src/features/shared/theme-toggle.tsx
+++ b/src/features/shared/theme-toggle.tsx
@@ -17,13 +17,13 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="rounded-full">
+        <Button variant="outline" size="icon" className="rounded-full border-border/60 bg-background/80 hover:bg-accent hover:border-border">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" side="top">
         <DropdownMenuItem onClick={() => setTheme("light")}>
           Light
         </DropdownMenuItem>

--- a/src/features/shared/theme-toggle.tsx
+++ b/src/features/shared/theme-toggle.tsx
@@ -17,13 +17,13 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon" className="rounded-full border-border/60 bg-background/80 hover:bg-accent hover:border-border">
+        <Button variant="ghost" size="icon" className="rounded-full">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" side="top">
+      <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setTheme("light")}>
           Light
         </DropdownMenuItem>

--- a/src/features/shared/ui/card-effects.tsx
+++ b/src/features/shared/ui/card-effects.tsx
@@ -78,16 +78,6 @@ export function CardEffects({ children, variant = "default", className = "" }: C
   );
 }
 
-// Reusable class names for consistent styling
 export const cardBaseClasses = {
   contentWrapper: "relative flex flex-col gap-4 p-6",
-  title: "font-semibold tracking-tight text-zinc-800 group-hover:text-purple-950 dark:text-zinc-100 dark:group-hover:text-white transition-colors",
-  description: "text-sm text-zinc-600 dark:text-zinc-400 group-hover:text-purple-900/90 dark:group-hover:text-zinc-300 transition-colors",
-  badge: "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium shadow-sm shadow-purple-500/10 dark:shadow-black/20 backdrop-blur-[2px] group-hover:shadow-purple-500/20 transition-all duration-500",
-  tag: "px-2 py-1 text-xs rounded-md bg-purple-100/60 text-purple-900 dark:bg-purple-500/10 dark:text-purple-300 border border-purple-300/40 dark:border-purple-500/10 group-hover:bg-purple-200/60 group-hover:border-purple-400/40 dark:group-hover:bg-purple-500/20 transition-colors duration-500 backdrop-blur-[2px]",
-  button: "inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-all duration-500 shadow-sm shadow-purple-500/10 dark:shadow-black/20 hover:shadow-md hover:shadow-purple-500/20 dark:hover:shadow-black/30 backdrop-blur-[2px] focus:outline-none focus:ring-2 focus:ring-purple-500/40 dark:focus:ring-purple-500/40 focus:ring-offset-2",
-  buttonGradient: {
-    default: "bg-gradient-to-r from-purple-200/80 via-cyan-200/80 to-pink-200/80 hover:from-purple-300/90 hover:via-cyan-300/90 hover:to-pink-300/90 text-purple-950 dark:from-purple-500/70 dark:via-cyan-500/70 dark:to-pink-500/70 dark:hover:from-purple-500/80 dark:hover:via-cyan-500/80 dark:hover:to-pink-500/80 dark:text-white",
-    featured: "bg-gradient-to-r from-purple-500/90 via-cyan-500/90 to-pink-500/90 hover:from-purple-500 hover:via-cyan-500 hover:to-pink-500 text-white",
-  },
-}; 
+};

--- a/src/features/shared/ui/dropdown-menu.tsx
+++ b/src/features/shared/ui/dropdown-menu.tsx
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-zinc-200 dark:border-zinc-700 bg-popover p-1 text-popover-foreground shadow-md",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}

--- a/src/features/shared/ui/sheet.tsx
+++ b/src/features/shared/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 bg-white dark:bg-zinc-950 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {

--- a/src/features/shared/ui/sheet.tsx
+++ b/src/features/shared/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-white dark:bg-zinc-950 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 bg-white dark:bg-zinc-800 p-6 shadow-xl transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -32,3 +32,34 @@ export const THEME = {
 export const API = {
   github: 'https://api.github.com',
 };
+
+// Site launch year — used by footer copyright range
+export const SITE_LAUNCH_YEAR = 2024;
+
+// Per-page SEO metadata — all page metadata exports import from here
+export const PAGE_META = {
+  home: {
+    title: "Hammayo's | Backend Software Engineer",
+    description: 'Portfolio site showcasing 20+ years of backend engineering across finance, justice, and public service.',
+  },
+  about: {
+    title: "About | Hammayo's Portfolio",
+    description: 'Senior backend engineer with 20+ years building distributed systems across finance, justice, and public service.',
+  },
+  blogs: {
+    title: "Blogs | Hammayo's Portfolio",
+    description: 'Technical writing on backend systems, architecture, and engineering craft.',
+  },
+  cv: {
+    title: "CV | Hammayo's Portfolio",
+    description: "Hammy Babar's professional CV and experience.",
+  },
+  projects: {
+    title: "Projects | Hammayo's Portfolio",
+    description: 'Explore my latest projects and open source contributions on GitHub.',
+  },
+  contact: {
+    title: "Contact | Hammayo's Portfolio",
+    description: 'Get in touch via GitHub, LinkedIn, or email.',
+  },
+};


### PR DESCRIPTION
### Pages delivered

  | Page | Description |
  |---|---|
  | `/` | Expanded homepage — dynamic bio, skills strip, CTA row |
  | `/about` | Avatar, bio, sectors & domains, philosophy quote |
  | `/projects` | Redesigned — scheme-aware topic tags, gradient heading |
  | `/contact` | `ContactCard` components per channel (GitHub, LinkedIn, email) |
  | `/blogs` | Styled placeholder — data-driven, "coming soon" badge |
  | `/cv` | Styled placeholder — LinkedIn link, data-driven |

  All pages use `PageTransitionWrapper`, `gradientText`/`accentTag` CVA variants, and the scheme CSS var system.

  ---

  ### Navigation

  - Mobile hamburger sheet nav (Radix `Sheet`) with accessible `SheetTitle` for screen readers
  - Active link highlighted with animated gradient span, trailing-slash-safe path comparison
  - Dynamic copyright year component (`CopyrightYear`) in footer
  - Sitemap updated with all Phase 2 routes

  ---

  ### Polish & fixes applied post-implementation

  | Fix | Detail |
  |---|---|
  | CTA buttons | Hardcoded `violet-600 → purple-600 → indigo-600` gradient — scheme CSS vars produced washed-out colours in morning scheme |
  | Route progress bar | Moved inside `<Header>` as `absolute bottom-0`; double-`requestAnimationFrame` fix so 0%→100% animation actually runs (React was
  batching the state updates) |
  | Page transitions | Removed `y` translate (caused layout reflow/jank on every nav); opacity-only fade at 150ms |
  | Mobile sheet background | Explicit `bg-white dark:bg-zinc-800` — `bg-background` CSS var not reliably opaque over fixed animated background |
  | Theme toggle | Opens `side="top"` above footer; dropdown menu border changed to `zinc-200/zinc-700` (was invisible in light mode) |
  | Footer alignment | Container constraints (`px-4 mx-auto max-w-7xl`) added to match header |
  | Gradient text contrast | `brightness(0.65) saturate(1.3)` filter in light mode for readability |
  | Font | Switched body font to JetBrains Mono — single font, terminal aesthetic |

  ---

  ### Code cleanup (included in this branch)

  - Deleted unused `Loading` component (`src/features/shared/loading.tsx`)
  - Removed dead `cardBaseClasses` properties (`title`, `description`, `badge`, `tag`, `button`, `buttonGradient`) — only `contentWrapper` was used
  - Fixed `about-content.tsx` fallback image to use `basePath` prefix for GitHub Pages static export

  ---

  ### Deviations from spec

  | Spec | Built | Reason |
  |---|---|---|
  | `ctaButton` uses `gradient-bg` scheme vars | Hardcoded violet gradient | Scheme vars washed out in morning/silver scheme |
  | Progress bar at `top-[45px]` (fixed) | `absolute bottom-0` inside `<Header>` | Hardcoded value misaligned on mobile |
  | Sheet uses `bg-background` | `bg-white dark:bg-zinc-800` | CSS var not reliably opaque over fixed animated background |

  ---

  ### Test checklist

  - [ ] All pages load: `/`, `/about`, `/projects`, `/contact`, `/cv`, `/blogs`
  - [ ] Mobile sheet nav opens/closes; background fully opaque over animated background
  - [ ] Route progress bar fills left→right and fades out on every navigation
  - [ ] Page transitions are smooth with no layout jank
  - [ ] CTA buttons render with violet gradient in all schemes (light + dark)
  - [ ] Theme toggle opens above footer; dropdown border visible in light mode
  - [ ] Footer content aligns with header at all breakpoints
  - [ ] `bun run build` passes with zero errors
