### PR TITLE
feat: blog list search reposition, pagination, and header polish

### DIFF
--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -22,17 +22,14 @@ export default function BlogsPage() {
     <PageTransitionWrapper>
       <PageViewEvent page="blogs" />
       <Container className="py-8">
-        <PageHeader title="Writing" subtitle={authoredSubtitle} className="mb-2" />
-        {postCount && (
-          <p className="text-xs text-muted-foreground mb-8">{postCount}</p>
-        )}
+        <PageHeader title="Writing" subtitle={authoredSubtitle} className="mb-4" />
 
         {posts.length === 0 ? (
           <p className="text-sm text-muted-foreground py-8">
             No posts yet — check back soon.
           </p>
         ) : (
-          <BlogList posts={posts} pinnedTags={blogsConfig.pinnedTags} />
+          <BlogList posts={posts} pinnedTags={blogsConfig.pinnedTags} postCount={postCount} />
         )}
       </Container>
     </PageTransitionWrapper>

--- a/src/features/blogs/blog-list.tsx
+++ b/src/features/blogs/blog-list.tsx
@@ -30,9 +30,8 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
 
   return (
     <div>
-      {/* Toolbar: search button + tag chips */}
-      <div className="flex flex-wrap items-center gap-2 mb-6">
-        {/* Search trigger */}
+      {/* Search row — right-aligned above pills */}
+      <div className="flex justify-end mb-2">
         <button
           onClick={() => setSearchOpen(true)}
           className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--scheme-border)] text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -46,8 +45,10 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
             ⌘K
           </kbd>
         </button>
+      </div>
 
-        {/* Tag filter chips */}
+      {/* Tag filter chips */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
         <button
           onClick={() => setActiveTag(null)}
           className={cn(

--- a/src/features/blogs/blog-list.tsx
+++ b/src/features/blogs/blog-list.tsx
@@ -10,9 +10,10 @@ import type { PostMeta } from './schema';
 interface BlogListProps {
   posts: PostMeta[];
   pinnedTags: string[];
+  postCount?: string | null;
 }
 
-export function BlogList({ posts, pinnedTags }: BlogListProps) {
+export function BlogList({ posts, pinnedTags, postCount }: BlogListProps) {
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -38,8 +39,13 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
 
   return (
     <div>
-      {/* Search row — right-aligned above pills */}
-      <div className="flex justify-end mb-2">
+      {/* Count + search row */}
+      <div className="flex items-center justify-between mb-2">
+        {postCount ? (
+          <p className="text-xs text-muted-foreground">{postCount}</p>
+        ) : (
+          <span />
+        )}
         <button
           onClick={() => setSearchOpen(true)}
           className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--scheme-border)] text-sm text-muted-foreground hover:text-foreground transition-colors"
@@ -134,10 +140,10 @@ interface PaginationProps {
 
 function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
   const pageItems = getPageWindow(currentPage, totalPages);
-  const btnBase = 'px-3 py-1.5 rounded-lg border border-[var(--scheme-border)] text-sm transition-colors';
-  const btnActive = cn(accentTag(), 'cursor-pointer');
-  const btnInactive = cn(btnBase, 'text-muted-foreground hover:text-foreground cursor-pointer');
-  const btnDisabled = cn(btnBase, 'text-muted-foreground opacity-40 cursor-not-allowed pointer-events-none');
+  const btnBase = 'inline-flex items-center justify-center min-w-[2rem] h-8 px-3 rounded-lg border text-sm transition-colors';
+  const btnActive = cn(btnBase, 'border-[var(--scheme-accent)] bg-[var(--scheme-accent)]/10 text-[var(--scheme-accent-text)] font-medium cursor-pointer');
+  const btnInactive = cn(btnBase, 'border-[var(--scheme-border)] text-muted-foreground hover:text-foreground hover:border-[var(--scheme-border)] cursor-pointer');
+  const btnDisabled = cn(btnBase, 'border-[var(--scheme-border)] text-muted-foreground opacity-40 cursor-not-allowed pointer-events-none');
 
   return (
     <div className="flex items-center justify-center gap-1 mt-8">

--- a/src/features/blogs/blog-list.tsx
+++ b/src/features/blogs/blog-list.tsx
@@ -15,6 +15,7 @@ interface BlogListProps {
 export function BlogList({ posts, pinnedTags }: BlogListProps) {
   const [activeTag, setActiveTag] = useState<string | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
 
   // Collect all unique tags; pinned tags come first, rest alphabetically
   const allTags = useMemo(() => {
@@ -27,6 +28,13 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
   const filtered = activeTag
     ? posts.filter(p => p.tags.includes(activeTag))
     : posts;
+
+  const POSTS_PER_PAGE = 6;
+  const totalPages = Math.ceil(filtered.length / POSTS_PER_PAGE);
+  const paginated = filtered.slice(
+    (currentPage - 1) * POSTS_PER_PAGE,
+    currentPage * POSTS_PER_PAGE
+  );
 
   return (
     <div>
@@ -50,7 +58,7 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
       {/* Tag filter chips */}
       <div className="flex flex-wrap items-center gap-2 mb-6">
         <button
-          onClick={() => setActiveTag(null)}
+          onClick={() => { setActiveTag(null); setCurrentPage(1); }}
           className={cn(
             accentTag(),
             'cursor-pointer transition-opacity',
@@ -62,7 +70,7 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
         {allTags.map(tag => (
           <button
             key={tag}
-            onClick={() => setActiveTag(activeTag === tag ? null : tag)}
+            onClick={() => { setActiveTag(activeTag === tag ? null : tag); setCurrentPage(1); }}
             className={cn(
               accentTag(),
               'cursor-pointer transition-opacity',
@@ -75,20 +83,95 @@ export function BlogList({ posts, pinnedTags }: BlogListProps) {
       </div>
 
       {/* Post grid */}
-      {filtered.length === 0 ? (
+      {paginated.length === 0 ? (
         <p className="text-sm text-muted-foreground py-8 text-center">
           No posts{activeTag ? ` tagged "${activeTag}"` : ''}.
         </p>
       ) : (
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          {filtered.map((post, i) => (
+          {paginated.map((post, i) => (
             <BlogCard key={post.slug} post={post} index={i} />
           ))}
         </div>
       )}
 
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      )}
+
       {/* Search palette */}
       <SearchPalette open={searchOpen} onOpenChange={setSearchOpen} />
+    </div>
+  );
+}
+
+function getPageWindow(current: number, total: number): (number | '...')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  const pages = new Set<number>([1, total, current]);
+  if (current > 1) pages.add(current - 1);
+  if (current < total) pages.add(current + 1);
+
+  const sorted = [...pages].sort((a, b) => a - b);
+  const result: (number | '...')[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) result.push('...');
+    result.push(sorted[i]);
+  }
+  return result;
+}
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+function Pagination({ currentPage, totalPages, onPageChange }: PaginationProps) {
+  const pageItems = getPageWindow(currentPage, totalPages);
+  const btnBase = 'px-3 py-1.5 rounded-lg border border-[var(--scheme-border)] text-sm transition-colors';
+  const btnActive = cn(accentTag(), 'cursor-pointer');
+  const btnInactive = cn(btnBase, 'text-muted-foreground hover:text-foreground cursor-pointer');
+  const btnDisabled = cn(btnBase, 'text-muted-foreground opacity-40 cursor-not-allowed pointer-events-none');
+
+  return (
+    <div className="flex items-center justify-center gap-1 mt-8">
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        className={currentPage === 1 ? btnDisabled : btnInactive}
+        aria-label="Previous page"
+      >
+        ←
+      </button>
+
+      {pageItems.map((item, i) =>
+        item === '...' ? (
+          <span key={`ellipsis-${i}`} className="px-2 text-sm text-muted-foreground">…</span>
+        ) : (
+          <button
+            key={item}
+            onClick={() => onPageChange(item)}
+            className={item === currentPage ? btnActive : btnInactive}
+            aria-label={`Page ${item}`}
+            aria-current={item === currentPage ? 'page' : undefined}
+          >
+            {item}
+          </button>
+        )
+      )}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        className={currentPage === totalPages ? btnDisabled : btnInactive}
+        aria-label="Next page"
+      >
+        →
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Search button repositioned** — moved from the shared toolbar row to its own right-aligned row above the tag pills
- **Post count merged with search row** — count and search button now share one tight `flex justify-between` line, eliminating the dead space between the page header and controls
- **Client-side pagination** — 6 posts per page, numbered page buttons with Prev/Next arrows and ellipsis windowing; resets on tag filter change; hidden when all posts fit on one page
- **Pagination button consistency** — all pagination buttons (numbers, active, Prev, Next) use identical base sizing (`min-w-8 h-8 px-3 rounded-lg text-sm`); active page differentiated by accent colour only

## Test plan

- [x] `bun run type-check` — passes
- [x] `bun run lint:strict` — passes
- [x] Search button appears right-aligned, post count left-aligned, on a single row below the page title
- [x] Tag pills on their own row below the count/search row
- [x] Page 1 shows ≤ 6 posts; pagination bar appears when total posts > 6
- [x] Clicking a page number navigates correctly; Prev disabled on page 1, Next disabled on last page
- [x] Switching tag filter resets to page 1
- [x] Pagination hidden when filtered results ≤ 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)