### PR TITLE
feat: add automatic back-merge of main into develop after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -82,3 +82,25 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  back-merge:
+    name: Back-merge main → develop
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Merge main into develop
+        run: |
+          git fetch origin main
+          git merge origin/main --no-ff -m "chore: back-merge main into develop [skip ci]"
+          git push origin develop


### PR DESCRIPTION
After every successful deployment to GitHub Pages, a back-merge job pushes the main into develop to keep branches permanently in sync. Also widens permissions.contents from read to write to allow the push.